### PR TITLE
Image/spatloc behavior update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Encoding: UTF-8
 LazyData: true
 URL: https://rubd.github.io/Giotto/, https://github.com/RubD/Giotto
 BugReports: https://github.com/RubD/Giotto/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Depends:
     base (>= 3.5.0),
     utils (>= 3.5.0),

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -104,16 +104,16 @@ set_expression_values <- function(gobject,
 #' @name get_spatial_locations
 #' @description function to get a spatial location data.table
 #' @param gobject giotto object
-#' @param spat_loc_name name of spatial locations
+#' @param spat_loc_name name of spatial locations (defaults to first name in spatial_locs slot)
 #' @return data.table with coordinates
 #' @export
 get_spatial_locations <- function(gobject,
-                                  spat_loc_name = 'raw') {
+                                  spat_loc_name = NULL) {
 
 
   # spatial locations
   # if NULL (not given) and spatial locations have been added, then use first one
-  # if NULL (not given) and spatial loactions have NOT been added, then keep NULL
+  # if NULL (not given) and spatial locations have NOT been added, then keep NULL
   if(is.null(spat_loc_name)) {
     if(!is.null(gobject@spatial_locs)) {
       spat_loc_name = names(gobject@spatial_locs)[[1]]

--- a/R/image_registration.R
+++ b/R/image_registration.R
@@ -314,10 +314,12 @@ registerGiottoObjectList = function(gobject_list,
 #' @description Function to spatially align gobject data based on FIJI image registration.
 #' @param gobject_list list of gobjects to register
 #' @param image_unreg name of original unregistered images. Defaults to 'image' (optional)
-#' @param image_reg_name Arbitrary name for registered images to occupy. Defaults to replacement of 'image' (optional)
+#' @param image_reg_name arbitrary name for registered images to occupy. Defaults to replacement of 'image' (optional)
+#' @param image_replace_name arbitrary name for any images replaced due to image_reg_name argument (optional)
 #' @param registered_images registered images output by FIJI register_virtual_stack_slices
 #' @param spatloc_unreg spatial locations to use. Defaults to 'raw' (optional)
 #' @param spatloc_reg_name name for registered spatial locations. Defaults to replacement of 'raw' (optional)
+#' @param spatloc_replace_name arbitrary name for any spatial locations replaced due to spatloc_reg_name argument (optional)
 #' @param xml_files atomic vector of filepaths to xml outputs from FIJI register_virtual_stack_slices
 #' @param scale_factor vector of scaling factors of images used in registration vs spatlocs
 #' @param verbose be verbose
@@ -326,9 +328,11 @@ registerGiottoObjectList = function(gobject_list,
 registerGiottoObjectListFiji = function(gobject_list,
                                         image_unreg = 'image',
                                         image_reg_name = 'image',
+                                        image_replace_name = 'unregistered',
                                         registered_images = NULL,
                                         spatloc_unreg = 'raw',
                                         spatloc_reg_name = 'raw',
+                                        spatloc_replace_name = 'unregistered',
                                         xml_files,
                                         scale_factor = NULL,
                                         verbose = TRUE) {
@@ -437,10 +441,10 @@ registerGiottoObjectListFiji = function(gobject_list,
     # Params check for conflicting names
     if(verbose == TRUE) {
       if(image_unreg == image_reg_name) {
-        cat('Image original name matches output name. Unregistered images renamed "unregistered". \n')
+        cat('Registered image name already used. Previous image named ', image_reg_name,' renamed to ',image_replace_name,'. \n')
       }
       if(spatloc_unreg == spatloc_reg_name) {
-        cat('Spatloc original name matches output name. Unregistered spatlocs renamed "unregistered". \n')
+        cat('Registered spatloc name already used. Previous spatloc named ', spatloc_reg_name,' renamed to ', spatloc_replace_name,'. \n')
       }
     }
 
@@ -449,7 +453,7 @@ registerGiottoObjectListFiji = function(gobject_list,
     #Rename original spatial locations to 'unregistered' if conflicting with output
     if(spatloc_unreg == spatloc_reg_name) {
       gobj = set_spatial_locations(gobject = gobj,
-                                   spat_loc_name = 'unregistered',
+                                   spat_loc_name = spatloc_replace_name,
                                    spatlocs = get_spatial_locations(gobject = gobj,
                                                                     spat_loc_name = spatloc_unreg))
     }
@@ -466,7 +470,7 @@ registerGiottoObjectListFiji = function(gobject_list,
     #If there is an existing image with the image_reg_name, rename it "unregistered"
     #Move the original image to 'unregistered'
     if(image_unreg == image_reg_name) {
-      gobj@images$unregistered = gobj@images[[image_unreg]]
+      gobj@images[[image_replace_name]] = gobj@images[[image_unreg]]
     }
 
     

--- a/man/addGiottoImage.Rd
+++ b/man/addGiottoImage.Rd
@@ -4,16 +4,16 @@
 \alias{addGiottoImage}
 \title{addGiottoImage}
 \usage{
-addGiottoImage(gobject, images, spat_loc_name = "raw", scale_factor = NULL)
+addGiottoImage(gobject, images, spat_loc_name = NULL, scale_factor = NULL)
 }
 \arguments{
 \item{gobject}{giotto object}
 
 \item{images}{list of giotto image objects, see \code{\link{createGiottoImage}}}
 
-\item{spat_loc_name}{provide spatial location slot in Giotto to align images. Defaults to 'raw'}
+\item{spat_loc_name}{provide spatial location slot in Giotto to align images. Defaults to first one}
 
-\item{scale_factor}{provide scale of image pixel dimensions relative to spatial coordinates. Defaults to 1:1}
+\item{scale_factor}{provide scale of image pixel dimensions relative to spatial coordinates.}
 }
 \value{
 an updated Giotto object with access to the list of images

--- a/man/createGiottoImage.Rd
+++ b/man/createGiottoImage.Rd
@@ -24,6 +24,8 @@ createGiottoImage(
 
 \item{spatial_locs}{spatial locations (alternative if giobject = NULL)}
 
+\item{spat_loc_name}{name of spatial locations within gobject}
+
 \item{mg_object}{magick image object}
 
 \item{name}{name for the image}

--- a/man/get_spatial_locations.Rd
+++ b/man/get_spatial_locations.Rd
@@ -4,12 +4,12 @@
 \alias{get_spatial_locations}
 \title{get_spatial_locations}
 \usage{
-get_spatial_locations(gobject, spat_loc_name = "raw")
+get_spatial_locations(gobject, spat_loc_name = NULL)
 }
 \arguments{
 \item{gobject}{giotto object}
 
-\item{spat_loc_name}{name of spatial locations}
+\item{spat_loc_name}{name of spatial locations (defaults to first name in spatial_locs slot)}
 }
 \value{
 data.table with coordinates

--- a/man/registerGiottoObjectListFiji.Rd
+++ b/man/registerGiottoObjectListFiji.Rd
@@ -8,9 +8,11 @@ registerGiottoObjectListFiji(
   gobject_list,
   image_unreg = "image",
   image_reg_name = "image",
+  image_replace_name = "unregistered",
   registered_images = NULL,
   spatloc_unreg = "raw",
   spatloc_reg_name = "raw",
+  spatloc_replace_name = "unregistered",
   xml_files,
   scale_factor = NULL,
   verbose = TRUE
@@ -21,13 +23,17 @@ registerGiottoObjectListFiji(
 
 \item{image_unreg}{name of original unregistered images. Defaults to 'image' (optional)}
 
-\item{image_reg_name}{Arbitrary name for registered images to occupy. Defaults to replacement of 'image' (optional)}
+\item{image_reg_name}{arbitrary name for registered images to occupy. Defaults to replacement of 'image' (optional)}
+
+\item{image_replace_name}{arbitrary name for any images replaced due to image_reg_name argument (optional)}
 
 \item{registered_images}{registered images output by FIJI register_virtual_stack_slices}
 
 \item{spatloc_unreg}{spatial locations to use. Defaults to 'raw' (optional)}
 
 \item{spatloc_reg_name}{name for registered spatial locations. Defaults to replacement of 'raw' (optional)}
+
+\item{spatloc_replace_name}{arbitrary name for any spatial locations replaced due to spatloc_reg_name argument (optional)}
 
 \item{xml_files}{atomic vector of filepaths to xml outputs from FIJI register_virtual_stack_slices}
 

--- a/man/rescaleGiottoImage.Rd
+++ b/man/rescaleGiottoImage.Rd
@@ -8,7 +8,7 @@ rescaleGiottoImage(
   gimage = NULL,
   gobject = NULL,
   image_name,
-  spatloc_name = "raw",
+  spatloc_name = NULL,
   scale_factor = NULL,
   resolution = NULL
 )
@@ -20,7 +20,7 @@ rescaleGiottoImage(
 
 \item{image_name}{name of giottoImage in giottoObject}
 
-\item{spatloc_name}{name of spatlocs that scaling is relative to (defaults to 'raw')}
+\item{spatloc_name}{name of spatlocs that scaling is relative to (defaults to first spatloc name for gobject or, if unavailable, "raw")}
 
 \item{scale_factor}{scale factor to convert from spatial distance to pixel distance}
 


### PR DESCRIPTION
Image functions now default to first available spatial location instead of "raw". If no spatial locations available in gobject, default to "raw" depending on the function's needs.
Added ability to choose the name to move old spatlocs and images that conflict with new names to for registerGiottoObjectListFiji()