### PR TITLE
HMRF/DWLS sparse to matrix patch

### DIFF
--- a/R/images.R
+++ b/R/images.R
@@ -837,6 +837,7 @@ addGiottoImageMG = function(gobject,
       if(sum(im@boundaries == c(0,0,0,0)) == 4 && sum(im@minmax == c(10,0,10,0)) == 4) {
         if(!is.null(spat_loc_name)) { # A check for the first available spatloc was already done
           spatlocs = get_spatial_locations(gobject = gobject,
+                                           spat_unit = spat_unit,
                                            spat_loc_name = spat_loc_name)
 
           #Find spatial minmax values

--- a/R/python_hmrf.R
+++ b/R/python_hmrf.R
@@ -119,7 +119,12 @@ doHMRF <- function(gobject,
                                         feat_type = feat_type,
                                         values = values)
   }
-  expr_values = as.matrix(expr_values)
+
+  if(class(expr_values) != 'matrix') {
+    warning('this matrix will be converted to a dense and memory intensive base matrix ...')
+    expr_values = as.matrix(expr_values)
+  }
+
 
   expression_file = paste0(output_folder,'/', 'expression_matrix.txt')
 

--- a/R/spatial_enrichment.R
+++ b/R/spatial_enrichment.R
@@ -1759,6 +1759,10 @@ runDWLSDeconv <- function(gobject,
                                       feat_type = feat_type,
                                       values = values)
 
+  if(class(expr_values) != 'matrix') {
+    warning('this matrix will be converted to a dense and memory intensive base matrix ...')
+    expr_values = as.matrix(expr_values)
+  }
 
   # #transform expression data to no log data
   nolog_expr = logbase^(expr_values)-1


### PR DESCRIPTION
HMRF and DWLS
Functions now convert non "matrix" class expr_values input into matrix via as.matrix.
A warning has been added to update this in the future.

Also added a missing spat_unit input in addGiottoImageMG()