### PR TITLE
lower-case giottoLargeImage

### DIFF
--- a/R/spatial_visuals.R
+++ b/R/spatial_visuals.R
@@ -37,7 +37,7 @@ plot_auto_largeImage_resample = function(gobject,
 
   # If no giottoLargeImage, select specified giottoLargeImage. If none specified, select first one.
   if(is.null(giottoLargeImage)) {
-    giottoLargeImage = get_GiottoLargeImage(gobject = gobject,
+    giottoLargeImage = get_giottoLargeImage(gobject = gobject,
                                     largeImage_name = largeImage_name)
   }
 


### PR DESCRIPTION
Line 40 in `spatial_visuals.R` uses the wrong case leading to upstream errors when calling functions like `spatInSituPlotPoints`

https://github.com/RubD/Giotto/blob/504943e5c4b35e2ae13c6aa30a69a4875add3541/R/spatial_visuals.R#L40