### PR TITLE
giotto points update

### DIFF
--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -185,8 +185,9 @@ plot_feature_points_layer = function(ggobject,
   feat_ID = NULL
 
   spatial_feat_info_subset = spatial_feat_info[feat_ID %in% unlist(feats)]
+  cat(' --| Plotting ', nrow(spatial_feat_info_subset), ' feature points\n')
 
-  if(!is.null(ggobject) & methods::is(ggobject, 'ggplot')) {
+  if(!is.null(ggobject) & inherits(ggobject, 'ggplot')) {
     pl = ggobject
   } else {
     pl = ggplot2::ggplot()

--- a/man/create_spatvector_object_from_dfr.Rd
+++ b/man/create_spatvector_object_from_dfr.Rd
@@ -10,6 +10,8 @@ create_spatvector_object_from_dfr(x)
 \item{x}{data.frame object}
 }
 \description{
-create terra spatvector from a data.frame
+create terra spatvector from a data.frame where cols 1 and 2 must
+be x and y coordinates respectively. Additional columns are set as attributes
+to the points where the first additional should be the feat_ID.
 }
 \keyword{internal}


### PR DESCRIPTION
Updated gpoints object creation behavior so that the first 'character' column seen is taken as the feat_ID column. The first two 'numeric' columns are taken as the x and y columns respectively. If any columns are given as 'feat_ID', 'x', or 'y', this behavior is skipped and those columns are directly taken.