### PR TITLE
Update createGiottoCosMxObject()

### DIFF
--- a/R/giotto.R
+++ b/R/giotto.R
@@ -1172,6 +1172,11 @@ check_spatial_location_data = function(gobject) {
         spatial_cell_id_names = gobject@spatial_locs[[spat_unit]][[coord]][['cell_ID']]
 
         if(!identical(spatial_cell_id_names, expected_cell_ID_names)) {
+          message('spatloc cell_IDs: ')
+          cat('  ', head(spatial_cell_id_names,3), '...', tail(spatial_cell_id_names,3), '\n')
+          message('expression cell_IDs: ')
+          cat('  ', head(expected_cell_ID_names,3), '...', tail(expected_cell_ID_names,3), '\n')
+          
           stop('cell_IDs between spatial and expression information are not the same for: \n
                  spatial unit: ', spat_unit, ' and coordinates: ', coord, ' \n')
         }

--- a/R/giotto.R
+++ b/R/giotto.R
@@ -3238,9 +3238,12 @@ joinGiottoObjects = function(gobject_list,
       poly_ids = gobj@spatial_info[[spat_info]]@spatVector$poly_ID
       gobj@spatial_info[[spat_info]]@spatVector$poly_ID = paste0(gname,'-',poly_ids)
 
-      # spatVecterCentroids
-      poly_ids = gobj@spatial_info[[spat_info]]@spatVectorCentroids$poly_ID
-      gobj@spatial_info[[spat_info]]@spatVectorCentroids$poly_ID = paste0(gname,'-',poly_ids)
+      # spatVectorCentroids
+      if(!is.null(gobj@spatial_info[[spat_info]]@spatVectorCentroids)) {
+        poly_ids = gobj@spatial_info[[spat_info]]@spatVectorCentroids$poly_ID
+        gobj@spatial_info[[spat_info]]@spatVectorCentroids$poly_ID = paste0(gname,'-',poly_ids)
+      }
+
 
       # overlaps??
       # TODO
@@ -3268,7 +3271,10 @@ joinGiottoObjects = function(gobject_list,
         if(verbose) cat('Spatial info: for ',spat_info, ' add_to_y = ', add_to_y, '\n')
 
         gobj@spatial_info[[spat_info]]@spatVector = terra::shift(x = gobj@spatial_info[[spat_info]]@spatVector, dx = add_to_x, dy = add_to_y)
-        gobj@spatial_info[[spat_info]]@spatVectorCentroids = terra::shift(x = gobj@spatial_info[[spat_info]]@spatVectorCentroids, dx = add_to_x, dy = add_to_y)
+        if(!is.null(gobj@spatial_info[[spat_info]]@spatVectorCentroids)) {
+          gobj@spatial_info[[spat_info]]@spatVectorCentroids = terra::shift(x = gobj@spatial_info[[spat_info]]@spatVectorCentroids, dx = add_to_x, dy = add_to_y)
+        }
+        
 
       }
 

--- a/man/createGiottoCosMxObject.Rd
+++ b/man/createGiottoCosMxObject.Rd
@@ -35,3 +35,35 @@ a giotto object
 Given the path to a CosMx experiment directory, creates a Giotto
 object.
 }
+\details{
+[\strong{Expected Directory}] This function generates a giotto object when given a 
+link to a cosmx output directory. It expects the following items within the directory
+where the \strong{bolded} portions are what this function matches against:
+\itemize{
+  \item{\strong{CellComposite} (folder of images)}
+  \item{\strong{CellLabels} (folder of images)}
+  \item{\strong{CellOverlay} (folder of images)}
+  \item{\strong{CompartmentLabels} (folder of images)}
+  \item{experimentname_\strong{exprMat_file}.csv (file)}
+  \item{experimentname_\strong{fov_positions_file}.csv (file)}
+  \item{experimentname_\strong{metadata_file}.csv (file)}
+  \item{experimentname_\strong{tx_file}.csv (file)}
+}
+
+[\strong{Workflows}] Workflow to use is accessed through the data_to_use param
+\itemize{
+  \item{'all' - loads and requires subcellular information from tx_file and fov_positions_file
+  and also the existing aggregated information (expression, spatial locations, and metadata)
+  from exprMat_file and metadata_file.}
+  \item{'subcellular' - loads and requires subcellular information from tx_file and 
+  fov_positions_file only.}
+  \item{'aggregate' - loads and requires the existing aggregate information (expression, 
+  spatial locations, and metadata) from exprMat_file and metadata_file.}
+}
+
+[\strong{Images}] Images in the default CellComposite, CellLabels, CompartmentLabels, and CellOverlay
+folders will be loaded as giotto largeImage objects in all workflows as long as they are available.
+Additionally, CellComposite images will be converted to giotto image objects, making plotting with
+these image objects more responsive when accessing them from a server.
+\code{\link{showGiottoImageNames()}} can be used to see the available images.
+}


### PR DESCRIPTION
- Added documentation.
- 'all' workflow where subcellular information is loaded as 'cell' spat_unit (default) and pre-generated aggregate information is appended as 'cell_agg' spat_unit has been added.
- Additional changes to joinGiottoObjects() and check_spatial_location_data() to make them more flexible