### PR TITLE
Add function for message formatting

### DIFF
--- a/R/giotto.R
+++ b/R/giotto.R
@@ -1447,7 +1447,7 @@ read_spatial_networks = function(gobject,
                                  spatial_network) {
 
   if(is.null(spatial_network)) {
-    cat('No spatial networks are provided \n')
+    message('No spatial networks are provided')
     return(gobject)
 
   } else {
@@ -1502,7 +1502,7 @@ read_spatial_enrichment = function(gobject,
                                    spatial_enrichment) {
 
   if(is.null(spatial_enrichment)) {
-    cat('No spatial enrichment results are provided \n')
+    message('No spatial enrichment results are provided')
     return(gobject)
 
   } else {
@@ -1550,7 +1550,7 @@ read_dimension_reduction <- function(gobject,
 
 
   if(is.null(dimension_reduction)) {
-    cat('No dimension reduction results are provided \n')
+    message('No dimension reduction results are provided')
     return(gobject)
 
   } else {
@@ -1600,7 +1600,7 @@ read_nearest_networks = function(gobject,
                                  nn_network) {
 
   if(is.null(nn_network)) {
-    cat('No nearest network results are provided \n')
+    message('No nearest network results are provided')
     return(gobject)
 
   } else {
@@ -1895,16 +1895,15 @@ createGiottoObject <- function(expression,
   ## check if all optional packages are installed
   # TODO: update at the end
   # TODO: extract from suggest field of DESCRIPTION
-  extra_packages = c("scran", "MAST", "png", "tiff", "biomaRt", "trendsceek", "multinet", "RTriangle", "FactoMiner")
+  extra_packages = c("scran", "MAST", "png", "tiff", "biomaRt", "trendsceek", "multinet", "RTriangle", "FactoMineR")
 
   pack_index = extra_packages %in% rownames(utils::installed.packages())
   extra_installed_packages = extra_packages[pack_index]
   extra_not_installed_packages = extra_packages[!pack_index]
 
   if(any(pack_index == FALSE) == TRUE) {
-    cat("Consider to install these (optional) packages to run all possible Giotto commands for spatial analyses: ",
-        extra_not_installed_packages)
-    cat("\n Giotto does not automatically install all these packages as they are not absolutely required and this reduces the number of dependencies \n")
+    wrap_msg("Consider to install these (optional) packages to run all possible Giotto commands for spatial analyses: ", extra_not_installed_packages)
+    wrap_msg(" Giotto does not automatically install all these packages as they are not absolutely required and this reduces the number of dependencies")
   }
 
 
@@ -1936,7 +1935,7 @@ createGiottoObject <- function(expression,
 
   }
 
-  if(verbose) cat('finished expression data \n')
+  if(verbose) message('finished expression data')
 
 
   ## parameters ##
@@ -2014,7 +2013,7 @@ createGiottoObject <- function(expression,
     }
   }
 
-  if(verbose) cat('finished spatial location data \n')
+  if(verbose) message('finished spatial location data')
 
 
   ## spatial info ##
@@ -2035,7 +2034,7 @@ createGiottoObject <- function(expression,
   gobject = set_cell_metadata(gobject = gobject,
                               cell_metadata = cell_metadata)
 
-  if(verbose) cat('finished cell metadata  \n')
+  if(verbose) message('finished cell metadata')
 
   ## feat metadata ##
   ## ------------- ##
@@ -2213,7 +2212,7 @@ createGiottoVisiumObject = function(visium_dir = NULL,
 
   if(!is.null(h5_visium_path)) {
 
-    if(verbose) cat("A path to an .h5 10X file was provided and will be used \n")
+    if(verbose) wrap_msg("A path to an .h5 10X file was provided and will be used \n")
 
     if(!file.exists(h5_visium_path)) stop("The provided path ", h5_visium_path, " does not exist \n")
 
@@ -2245,7 +2244,7 @@ createGiottoVisiumObject = function(visium_dir = NULL,
 
       if(png_name == 'tissue_lowres_image.png') {
         if(file.exists(h5_json_scalefactors_path)) {
-          if(verbose == TRUE && do_manual_adj == FALSE) cat('png and scalefactors paths are found and automatic alignment for the lowres image will be attempted \n')
+          if(verbose == TRUE && do_manual_adj == FALSE) wrap_msg('png and scalefactors paths are found and automatic alignment for the lowres image will be attempted\n\n')
 
           json_info = jsonlite::read_json(h5_json_scalefactors_path)
           scale_factor = json_info[['tissue_lowres_scalef']]
@@ -2264,7 +2263,7 @@ createGiottoVisiumObject = function(visium_dir = NULL,
         }
       } else if(png_name == 'tissue_hires_image.png') {
         if(file.exists(h5_json_scalefactors_path)) {
-          if(verbose == TRUE && do_manual_adj == FALSE) cat('png and scalefactors paths are found and automatic alignment for the hires image will be attempted \n')
+          if(verbose == TRUE && do_manual_adj == FALSE) wrap_msg('png and scalefactors paths are found and automatic alignment for the hires image will be attempted\n\n')
 
           json_info = jsonlite::read_json(h5_json_scalefactors_path)
           scale_factor = json_info[['tissue_hires_scalef']]
@@ -2310,7 +2309,7 @@ createGiottoVisiumObject = function(visium_dir = NULL,
 
   } else {
 
-    if(verbose) cat("A structured visium directory will be used \n")
+    if(verbose) message("A structured visium directory will be used \n")
 
     ## check arguments
     if(is.null(visium_dir)) stop('visium_dir needs to be a path to a visium directory \n')
@@ -2356,7 +2355,7 @@ createGiottoVisiumObject = function(visium_dir = NULL,
       scalefactors_path = paste0(spatial_path,'/','scalefactors_json.json')
 
       if(file.exists(scalefactors_path)) {
-        if(verbose == TRUE && do_manual_adj == FALSE) cat('png and scalefactors paths are found and automatic alignment for the lowres image will be attempted \n')
+        if(verbose == TRUE && do_manual_adj == FALSE) wrap_msg('png and scalefactors paths are found and automatic alignment for the lowres image will be attempted\n\n')
 
         json_info = jsonlite::read_json(scalefactors_path)
         scale_factor = json_info[['tissue_lowres_scalef']]
@@ -2378,7 +2377,7 @@ createGiottoVisiumObject = function(visium_dir = NULL,
       scalefactors_path = paste0(spatial_path,'/','scalefactors_json.json')
 
        if(file.exists(scalefactors_path)) {
-        if(verbose == TRUE && do_manual_adj == FALSE) cat('png and scalefactors paths are found and automatic alignment for the hires image will be attempted \n')
+        if(verbose == TRUE && do_manual_adj == FALSE) wrap_msg('png and scalefactors paths are found and automatic alignment for the hires image will be attempted\n\n')
 
         json_info = jsonlite::read_json(scalefactors_path)
         scale_factor = json_info[['tissue_hires_scalef']]
@@ -2396,10 +2395,14 @@ createGiottoVisiumObject = function(visium_dir = NULL,
 
       }
     } else {
-      visium_png = createGiottoImage(gobject = NULL, spatial_locs =  spatial_locs,
-                                     mg_object = png_path, name = 'image',
-                                     xmax_adj = xmax_adj, xmin_adj = xmin_adj,
-                                     ymax_adj = ymax_adj, ymin_adj = ymin_adj)
+      visium_png = createGiottoImage(gobject = NULL,
+                                     spatial_locs =  spatial_locs,
+                                     mg_object = png_path,
+                                     name = 'image',
+                                     xmax_adj = xmax_adj,
+                                     xmin_adj = xmin_adj,
+                                     ymax_adj = ymax_adj,
+                                     ymin_adj = ymin_adj)
     }
 
     visium_png_list = list(visium_png)
@@ -3452,7 +3455,7 @@ joinGiottoObjects = function(gobject_list,
   # expand z_vals if given as a step value
   if(join_method == 'z_stack') {
     if(length(z_vals) == 1) {
-      if(isTRUE(verbose)) cat('Only one value given through z_vals param\n Treating this value as a z step\n')
+      if(isTRUE(verbose)) message('Only one value given through z_vals param\n Treating this value as a z step')
       z_vals = ((1:length(gobject_list)) - 1) * z_vals # Find z vals stepwise
     }
   }
@@ -3483,7 +3486,7 @@ joinGiottoObjects = function(gobject_list,
 
   ## 1. update giotto objects ##
   ## ------------------------ ##
-  if(verbose == TRUE) cat('start updating objects \n')
+  if(verbose == TRUE) message('start updating objects')
 
   all_feat_ID_list = list()
   all_cell_ID_list = list()
@@ -3911,7 +3914,7 @@ joinGiottoObjects = function(gobject_list,
 
   ## expression and feat IDs
   ## if no expression matrices are provided, then just combine all feature IDs
-  if(verbose == TRUE) cat('start expression combination \n')
+  if(verbose == TRUE) message('start expression combination')
 
   expr_names = names(first_obj@expression)
 

--- a/R/python_environment.R
+++ b/R/python_environment.R
@@ -23,13 +23,12 @@ checkGiottoEnvironment =  function(verbose = TRUE) {
   }
 
   if(file.exists(full_path)) {
-    if(verbose) cat('\n giotto environment found at \n',
-                    full_path, '\n')
+    if(verbose) message('\n giotto environment found at \n',
+                        full_path, '\n')
     return(TRUE)
 
   } else {
-    if(verbose) cat('\n giotto environment was expected, but NOT found at \n',
-                    full_path, '\n')
+    if(verbose) wrap_msg('\n giotto environment was expected, but NOT found at \n', full_path, '\n')
     return(FALSE)
   }
 
@@ -100,7 +99,7 @@ install_giotto_environment_specific = function(packages_to_install = c('pandas',
                                                verbose = TRUE) {
 
   ## install Giotto environment
-  if(verbose) cat('\n |---- install giotto environment ----| \n')
+  if(verbose) message('\n |---- install giotto environment ----| \n')
   conda_path = reticulate::miniconda_path()
 
   ## 3. identify operating system and adjust the necessary packages
@@ -191,7 +190,7 @@ install_giotto_environment = function(force_environment = FALSE,
   if(giotto_installed == TRUE & force_environment == FALSE) {
     # do nothing if already installed and no force required
 
-    if(verbose) cat('Giotto environment is already installed, set force_environment = TRUE to reinstall \n')
+    if(verbose) wrap_msg('Giotto environment is already installed, set force_environment = TRUE to reinstall \n')
 
   } else if(giotto_installed == TRUE & force_environment == TRUE) {
     # reinstall giotto if force required
@@ -281,7 +280,7 @@ installGiottoEnvironment =  function(packages_to_install = c('pandas==1.1.5',
   conda_path = reticulate::miniconda_path()
 
   if(!file.exists(conda_path) | isTRUE(force_miniconda)) {
-    if(verbose) cat('\n |---- install local miniconda ----| \n')
+    if(verbose) message('\n |---- install local miniconda ----| \n')
     reticulate::install_miniconda(force = force_miniconda)
   }
 
@@ -309,7 +308,7 @@ removeGiottoEnvironment = function(verbose = TRUE) {
   giotto_installed = checkGiottoEnvironment(verbose = verbose)
 
   if(giotto_installed == FALSE) {
-    cat('Giotto environment is not found and probably never installed')
+    wrap_msg('Giotto environment is not found and probably never installed')
   }
 
   # first remove giotto environment, then install
@@ -330,19 +329,19 @@ set_giotto_python_path = function(python_path = NULL) {
 
   ## if a python path is provided, use that path
   if(!is.null(python_path)) {
-    cat('\n external python path provided and will be used \n')
+    message('\n external python path provided and will be used \n')
     python_path = as.character(python_path)
     reticulate::use_python(required = T, python = python_path)
 
   } else if(giotto_environment_installed == TRUE) {
 
-    cat('\n no external python path was provided, but a giotto python environment was found and will be used \n')
+    wrap_msg('\n no external python path was provided, but a giotto python environment was found and will be used \n')
     python_path = return_giotto_environment_path_executable()
     reticulate::use_python(required = T, python = python_path)
 
   } else {
 
-    cat('\n no external python path or giotto environment was specified, will check if a default python path is available \n')
+    wrap_msg('\n no external python path or giotto environment was specified, will check if a default python path is available \n')
 
     if(.Platform[['OS.type']] == 'unix') {
       python_path = try(system('which python3', intern = T))
@@ -351,17 +350,17 @@ set_giotto_python_path = function(python_path = NULL) {
     }
 
     if(inherits(python_path, 'try-error')) {
-      cat('\n no default python path found, install python and/or use strategy 1 or 2 \n')
+      wrap_msg('\n no default python path found, install python and/or use strategy 1 or 2 \n')
       python_path = '/need/to/set/path/to/python'
     } else {
       python_path = python_path
       reticulate::use_python(required = T, python = python_path)
-      cat('\n A default python path was found: ', python_path, ' and will be used\n')
+      wrap_msg('\n A default python path was found: ', python_path, ' and will be used\n')
     }
 
-    cat('\n If this is not the correct python path, either\n')
-    cat('\n 1. use installGiottoEnvironment() to install a local miniconda python environment along with required modules \n')
-    cat('\n 2. provide an existing python path to python_path to use your own python path which has all modules installed \n')
+    wrap_msg('\n If this is not the correct python path, either')
+    wrap_msg('\n 1. use installGiottoEnvironment() to install a local miniconda python environment along with required modules')
+    wrap_msg('\n 2. provide an existing python path to python_path to use your own python path which has all modules installed')
 
   }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -409,4 +409,22 @@ box_chars <- function() {
 }
 
 
+# Print Formatting ####
+
+#' @title Wrap message
+#' @name wrap_msg
+#' @keywords internal
+#' @inheritDotParams string elements to pass to cat
+#' @param collapse how to join elements of string (default is no space)
+wrap_msg = function(..., collapse = '') {
+  cat(...) %>%
+    capture.output() %>%
+    strwrap() %>%
+    paste(., collapse = '\n') %>%
+    message()
+}
+
+
+
+
 


### PR DESCRIPTION
Added `wrap_msg` as a way to provide diagnostic printouts that will wrap to the console. It behaves similarly to `cat `and does NOT produce a final newline (unlike `message`) but the actual print is as a `message`.
Keep in mind that there may be times when `message` may be preferred over `wrap_msg` for example when text wrapping is not appropriate.