### PR TITLE
S4 provenance

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -208,7 +208,7 @@ setMethod('$<-', signature(x = 'metaData'),
 #' @export
 setMethod('[', signature(x = 'coordDataDT', i = 'missing', j = 'ANY', drop = 'missing'),
           function(x, i, j) {
-            x@coordinates = x@coordinates[, j = j]
+            x@coordinates = x@coordinates[, j = j, with = FALSE]
             x
           })
 
@@ -224,7 +224,7 @@ setMethod('[', signature(x = 'coordDataDT', i = 'ANY', j = 'missing', drop = 'mi
 #' @export
 setMethod('[', signature(x = 'coordDataDT', i = 'ANY', j = 'ANY', drop = 'missing'),
           function(x, i, j) {
-            x@coordinates = x@coordinates[i = i, j = j]
+            x@coordinates = x@coordinates[i = i, j = j, with = FALSE]
             x
           })
 
@@ -247,7 +247,7 @@ setMethod('[', signature(x = 'coordDataDT', i = 'missing', j = 'missing', drop =
 #' @export
 setMethod('[', signature(x = 'metaData', i = 'missing', j = 'ANY', drop = 'missing'),
           function(x, i, j) {
-            x@coordinates = x@metaDT[, j = j]
+            x@metaDT = x@metaDT[, j = j, with = FALSE]
             x
           })
 
@@ -255,7 +255,7 @@ setMethod('[', signature(x = 'metaData', i = 'missing', j = 'ANY', drop = 'missi
 #' @export
 setMethod('[', signature(x = 'metaData', i = 'ANY', j = 'missing', drop = 'missing'),
           function(x, i, j) {
-            x@coordinates = x@metaDT[i = i,]
+            x@metaDT = x@metaDT[i = i,]
             x
           })
 
@@ -263,7 +263,7 @@ setMethod('[', signature(x = 'metaData', i = 'ANY', j = 'missing', drop = 'missi
 #' @export
 setMethod('[', signature(x = 'metaData', i = 'ANY', j = 'ANY', drop = 'missing'),
           function(x, i, j) {
-            x@coordinates = x@metaDT[i = i, j = j]
+            x@metaDT = x@metaDT[i = i, j = j, with = FALSE]
             x
           })
 

--- a/man/extract-generic.Rd
+++ b/man/extract-generic.Rd
@@ -7,13 +7,16 @@
 \alias{$,metaData-method}
 \alias{$<-,metaData-method}
 \alias{[,coordDataDT,missing,ANY,missing-method}
+\alias{[,coordDataDT,ANY,missing,missing-method}
 \alias{[,coordDataDT,ANY,ANY,missing-method}
 \alias{[,coordDataDT,missing,missing,missing-method}
 \alias{[,metaData,missing,ANY,missing-method}
+\alias{[,metaData,ANY,missing,missing-method}
 \alias{[,metaData,ANY,ANY,missing-method}
 \alias{[,metaData,missing,missing,missing-method}
 \alias{[,dimObj,ANY,ANY,missing-method}
 \alias{[,exprData,missing,ANY,missing-method}
+\alias{[,exprData,ANY,missing,missing-method}
 \alias{[,exprData,ANY,ANY,missing-method}
 \alias{[,exprData,missing,missing,missing-method}
 \title{Extract or replace parts of an object}
@@ -28,7 +31,7 @@
 
 \S4method{[}{coordDataDT,missing,ANY,missing}(x, i, j)
 
-\S4method{[}{coordDataDT,missing,ANY,missing}(x, i, j)
+\S4method{[}{coordDataDT,ANY,missing,missing}(x, i, j)
 
 \S4method{[}{coordDataDT,ANY,ANY,missing}(x, i, j)
 
@@ -36,7 +39,7 @@
 
 \S4method{[}{metaData,missing,ANY,missing}(x, i, j)
 
-\S4method{[}{metaData,missing,ANY,missing}(x, i, j)
+\S4method{[}{metaData,ANY,missing,missing}(x, i, j)
 
 \S4method{[}{metaData,ANY,ANY,missing}(x, i, j)
 
@@ -46,7 +49,7 @@
 
 \S4method{[}{exprData,missing,ANY,missing}(x, i, j)
 
-\S4method{[}{exprData,missing,ANY,missing}(x, i, j)
+\S4method{[}{exprData,ANY,missing,missing}(x, i, j)
 
 \S4method{[}{exprData,ANY,ANY,missing}(x, i, j)
 

--- a/man/read_feature_metadata.Rd
+++ b/man/read_feature_metadata.Rd
@@ -4,12 +4,16 @@
 \alias{read_feature_metadata}
 \title{Read feature metadata}
 \usage{
-read_feature_metadata(gobject, metadata)
+read_feature_metadata(gobject, metadata, provenance = NULL, verbose = TRUE)
 }
 \arguments{
 \item{gobject}{giotto object}
 
 \item{metadata}{nested list of feature metadata information}
+
+\item{provenance}{provenance information (optional)}
+
+\item{verbose}{be verbose}
 }
 \description{
 read feature metadata from list


### PR DESCRIPTION
fix typos with data.table generics that prevent usage of j in [i, j] subsetting.

Also issue where metaData class accessor is wrongly referencing a coordinates slot