### PR TITLE
S4 data.table set by reference functionality

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -55,6 +55,7 @@ setClass('coordDataDT',
 
 setMethod('initialize', 'coordDataDT',
           function(.Object, ...) {
+            .Object = callNextMethod()
             # prepare DT for set by reference
             .Object@coordinates = data.table::setalloccol(.Object@coordinates)
             .Object
@@ -80,6 +81,7 @@ setClass('metaData',
 
 setMethod('initialize', 'metaData',
           function(.Object, ...) {
+            .Object = callNextMethod()
             # prepare DT for set by reference
             .Object@metaDT = data.table::setalloccol(.Object@metaDT)
             .Object
@@ -95,6 +97,7 @@ setClass('enrData',
 
 setMethod('initialize', 'enrData',
           function(.Object, ...) {
+            .Object = callNextMethod()
             # prepare DT for set by reference
             .Object@enrichDT = data.table::setalloccol(.Object@enrichDT)
             .Object
@@ -127,6 +130,7 @@ setClass('spatNetData',
 
 setMethod('initialize', 'spatNetData',
           function(.Object, ...) {
+            .Object = callNextMethod()
             # prepare DT for set by reference
             .Object@networkDT = data.table::setalloccol(.Object@networkDT)
             .Object@networkDT_before_filter = data.table::setalloccol(.Object@networkDT_before_filter)
@@ -146,6 +150,7 @@ setClass('spatGridData',
 
 setMethod('initialize', 'spatGridData',
           function(.Object, ...) {
+            .Object = callNextMethod()
             # prepare DT for set by reference
             .Object@gridDT = data.table::setalloccol(.Object@gridDT)
             .Object

--- a/R/classes.R
+++ b/R/classes.R
@@ -53,6 +53,13 @@ setClass('coordDataDT',
          representation = list(coordinates = 'data.table'),
          prototype = prototype(coordinates = data.table::data.table()))
 
+setMethod('initialize', 'coordDataDT',
+          function(.Object, ...) {
+            # prepare DT for set by reference
+            .Object@coordinates = data.table::setalloccol(.Object@coordinates)
+            .Object
+          })
+
 # setClass('coordDataMT',
 #          representation = list(coordinates = 'matrix'),
 #          prototype = prototype(coordinates = matrix()))
@@ -71,12 +78,28 @@ setClass('metaData',
                                col_desc = NA_character_))
 
 
+setMethod('initialize', 'metaData',
+          function(.Object, ...) {
+            # prepare DT for set by reference
+            .Object@metaDT = data.table::setalloccol(.Object@metaDT)
+            .Object
+          })
+
+
 # ** enrData ####
 setClass('enrData',
          representation = list(method = 'character',
                                enrichDT = 'nullOrDatatable'),
          prototype = prototype(method = NA_character_,
                                enrichDT = NULL))
+
+setMethod('initialize', 'enrData',
+          function(.Object, ...) {
+            # prepare DT for set by reference
+            .Object@enrichDT = data.table::setalloccol(.Object@enrichDT)
+            .Object
+          })
+
 
 
 # ** nnData ####
@@ -102,6 +125,15 @@ setClass('spatNetData',
                                networkDT_before_filter = NULL,
                                cellShapeObj = NULL))
 
+setMethod('initialize', 'spatNetData',
+          function(.Object, ...) {
+            # prepare DT for set by reference
+            .Object@networkDT = data.table::setalloccol(.Object@networkDT)
+            .Object@networkDT_before_filter = data.table::setalloccol(.Object@networkDT_before_filter)
+            .Object
+          })
+
+
 # ** spatGridData ####
 setClass('spatGridData',
          representation = list(method = 'character',
@@ -111,6 +143,13 @@ setClass('spatGridData',
                                parameters = NULL,
                                gridDT = NULL))
 
+
+setMethod('initialize', 'spatGridData',
+          function(.Object, ...) {
+            # prepare DT for set by reference
+            .Object@gridDT = data.table::setalloccol(.Object@gridDT)
+            .Object
+          })
 
 
 # ** provData Class ####

--- a/R/generics.R
+++ b/R/generics.R
@@ -1,6 +1,6 @@
 # Methods and Generics ####
 
-
+# NOTE: initialize generics are in classes.R #
 
 
 


### PR DESCRIPTION
Add ability to update S4 subobjects within gobject by reference
********
For example, it is now possible to `get` a data.table-based S4 subobject from the gobject with copy_obj = FALSE, modify it and then expect the modifications to be directly reflected within the gobject without having to `set` the object again.

This makes use of `data.table::setalloccol()` which allocates a default of 1024 columns for use in a set-by-reference manner. This default value can be changed via editing the 'initialize' generic for these S4 subobjects or setting a very large arbitrary number in data.table options such as `options(datatable.alloccol=10000L)`