### PR TITLE
Density visuals patch

### DIFF
--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -870,7 +870,7 @@ plot_feature_raster_density_layer = function(ggobject = NULL,
   pl = pl + ggplot2::stat_density_2d(data = spatial_feat_info_subset,
                                      ggplot2::aes_string(x = sdimx,
                                                          y = sdimy,
-                                                         fill = '..density..'),
+                                                         fill = 'after_stat(density)'),
                                      geom = "raster",
                                      alpha = alpha,
                                      contour = FALSE)

--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -615,6 +615,7 @@ spatInSituPlotHex_single = function(gobject,
                                     polygon_fill_as_factor = NULL,
                                     polygon_alpha = 0.5,
                                     polygon_size = 0.5,
+                                    coord_fix_ratio = NULL,
                                     axis_text = 8,
                                     axis_title = 8,
                                     legend_text = 6,
@@ -687,6 +688,10 @@ spatInSituPlotHex_single = function(gobject,
                                 panel.grid = element_blank(),
                                 panel.background = element_rect(fill = background_color))
 
+  # fix coord ratio
+  if(!is.null(coord_fix_ratio)) {
+    plot = plot + ggplot2::coord_fixed(ratio = coord_fix_ratio)
+  }
 
 
   return(plot)
@@ -712,6 +717,7 @@ spatInSituPlotHex_single = function(gobject,
 #' @param polygon_fill_as_factor is fill color a factor
 #' @param polygon_alpha alpha of polygon
 #' @param polygon_size size of polygon border
+#' @param coord_fix_ratio fix ratio between x and y-axis
 #' @param axis_text axis text size
 #' @param axis_title title text size
 #' @param legend_text legend text size
@@ -743,6 +749,7 @@ spatInSituPlotHex = function(gobject,
                              polygon_fill_as_factor = NULL,
                              polygon_alpha = 0.5,
                              polygon_size = 0.5,
+                             coord_fix_ratio = NULL,
                              axis_text = 8,
                              axis_title = 8,
                              legend_text = 6,
@@ -786,6 +793,7 @@ spatInSituPlotHex = function(gobject,
                                   polygon_fill_as_factor = polygon_fill_as_factor,
                                   polygon_alpha = polygon_alpha,
                                   polygon_size = polygon_size,
+                                  coord_fix_ratio = coord_fix_ratio,
                                   axis_text = axis_text,
                                   axis_title = axis_title,
                                   legend_text = legend_text,
@@ -885,6 +893,7 @@ spatInSituPlotDensity_single = function(gobject,
                                         polygon_fill_as_factor = NULL,
                                         polygon_alpha = 0.5,
                                         polygon_size = 0.5,
+                                        coord_fix_ratio = NULL,
                                         axis_text = 8,
                                         axis_title = 8,
                                         legend_text = 6,
@@ -955,6 +964,10 @@ spatInSituPlotDensity_single = function(gobject,
                                 panel.grid = element_blank(),
                                 panel.background = element_rect(fill = background_color))
 
+  # fix coord ratio
+  if(!is.null(coord_fix_ratio)) {
+    plot = plot + ggplot2::coord_fixed(ratio = coord_fix_ratio)
+  }
 
 
   return(plot)
@@ -979,6 +992,7 @@ spatInSituPlotDensity_single = function(gobject,
 #' @param polygon_fill_as_factor is fill color a factor
 #' @param polygon_alpha alpha of polygon
 #' @param polygon_size size of polygon border
+#' @param coord_fix_ratio fix ratio between x and y-axis
 #' @param axis_text axis text size
 #' @param axis_title title text size
 #' @param legend_text legend text size
@@ -1009,6 +1023,7 @@ spatInSituPlotDensity = function(gobject,
                                  polygon_fill_as_factor = NULL,
                                  polygon_alpha = 0.5,
                                  polygon_size = 0.5,
+                                 coord_fix_ratio = NULL,
                                  axis_text = 8,
                                  axis_title = 8,
                                  legend_text = 6,
@@ -1054,6 +1069,7 @@ spatInSituPlotDensity = function(gobject,
                                       polygon_fill_as_factor = polygon_fill_as_factor,
                                       polygon_alpha = polygon_alpha,
                                       polygon_size = polygon_size,
+                                      coord_fix_ratio = coord_fix_ratio,
                                       axis_text = axis_text,
                                       axis_title = axis_title,
                                       legend_text = legend_text,

--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -684,7 +684,8 @@ spatInSituPlotHex_single = function(gobject,
                                    sel_feat = feat,
                                    sdimx = sdimx,
                                    sdimy = sdimy,
-                                   binwidth = binwidth)
+                                   binwidth = binwidth,
+                                   min_axis_bins = min_axis_bins)
 
 
   ## adjust theme settings
@@ -796,6 +797,7 @@ spatInSituPlotHex = function(gobject,
                                   sdimx = sdimx,
                                   sdimy = sdimy,
                                   binwidth = binwidth,
+                                  min_axis_bins = min_axis_bins,
                                   alpha = alpha,
                                   show_polygon = show_polygon,
                                   polygon_feat_type = polygon_feat_type,

--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -565,17 +565,23 @@ spatInSituPlotPoints = function(gobject,
 #' @details This function can plot one feature for one modality.
 #' @keywords internal
 plot_feature_hexbin_layer = function(ggobject = NULL,
-                                      spatial_feat_info,
-                                      sel_feat,
-                                      sdimx = 'x',
-                                      sdimy = 'y',
-                                      bins = 10,
-                                      alpha = 0.5) {
+                                     spatial_feat_info,
+                                     sel_feat,
+                                     sdimx = 'x',
+                                     sdimy = 'y',
+                                     binwidth = NULL,
+                                     alpha = 0.5) {
 
   # data.table variables
   feat_ID = NULL
 
   spatial_feat_info_subset = spatial_feat_info[feat_ID %in% sel_feat]
+
+  # set default binwidth to 1/10 of minor axis
+  if(is.null(binwidth)) {
+    minorRange = spatial_feat_info_subset[, min(diff(sapply(.SD, range))), .SDcols = c('x','y')]
+    binwidth = as.integer(minorRange/10L)
+  }
 
   if(!is.null(ggobject) & methods::is(ggobject, 'ggplot')) {
     pl = ggobject
@@ -586,7 +592,7 @@ plot_feature_hexbin_layer = function(ggobject = NULL,
   pl = pl + ggplot2::geom_hex(data = spatial_feat_info_subset,
                               ggplot2::aes_string(x = sdimx,
                                                   y = sdimy),
-                              bins = bins,
+                              binwidth = binwidth,
                               alpha = alpha)
   pl = pl + labs(title = sel_feat)
   return(pl)
@@ -606,7 +612,7 @@ spatInSituPlotHex_single = function(gobject,
                                     feat_type = 'rna',
                                     sdimx = 'x',
                                     sdimy = 'y',
-                                    bins = 10,
+                                    binwidth = NULL,
                                     alpha = 0.5,
                                     show_polygon = TRUE,
                                     polygon_feat_type = 'cell',
@@ -672,11 +678,11 @@ spatInSituPlotHex_single = function(gobject,
   spatial_feat_info = do.call('rbind', spatial_feat_info)
 
   plot = plot_feature_hexbin_layer(ggobject = plot,
-                                    spatial_feat_info = spatial_feat_info,
-                                    sel_feat = feat,
-                                    sdimx = sdimx,
-                                    sdimy = sdimy,
-                                    bins = bins)
+                                   spatial_feat_info = spatial_feat_info,
+                                   sel_feat = feat,
+                                   sdimx = sdimx,
+                                   sdimy = sdimy,
+                                   bins = bins)
 
 
   ## adjust theme settings
@@ -707,7 +713,7 @@ spatInSituPlotHex_single = function(gobject,
 #' @param feat_type feature types of the feats
 #' @param sdimx spatial dimension x
 #' @param sdimy spatial dimension y
-#' @param bins number of hexbins in one direction
+#' @param binwidth numeric vector for x and y width of bins (default is 1/10 of minor axis)
 #' @param alpha alpha of hexbin plot
 #' @param show_polygon overlay polygon information (cell shape)
 #' @param polygon_feat_type feature type associated with polygon information
@@ -739,7 +745,7 @@ spatInSituPlotHex = function(gobject,
                              feat_type = 'rna',
                              sdimx = 'x',
                              sdimy = 'y',
-                             bins = 10,
+                             binwidth = NULL,
                              alpha = 0.5,
                              show_polygon = TRUE,
                              polygon_feat_type = 'cell',

--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -570,6 +570,7 @@ plot_feature_hexbin_layer = function(ggobject = NULL,
                                      sdimx = 'x',
                                      sdimy = 'y',
                                      binwidth = NULL,
+                                     min_axis_bins = 10L,
                                      alpha = 0.5) {
 
   # data.table variables
@@ -580,7 +581,7 @@ plot_feature_hexbin_layer = function(ggobject = NULL,
   # set default binwidth to 1/10 of minor axis
   if(is.null(binwidth)) {
     minorRange = spatial_feat_info_subset[, min(diff(sapply(.SD, range))), .SDcols = c('x','y')]
-    binwidth = as.integer(minorRange/10L)
+    binwidth = as.integer(minorRange/min_axis_bins)
   }
 
   if(!is.null(ggobject) & methods::is(ggobject, 'ggplot')) {
@@ -613,6 +614,7 @@ spatInSituPlotHex_single = function(gobject,
                                     sdimx = 'x',
                                     sdimy = 'y',
                                     binwidth = NULL,
+                                    min_axis_bins = NULL,
                                     alpha = 0.5,
                                     show_polygon = TRUE,
                                     polygon_feat_type = 'cell',
@@ -713,7 +715,10 @@ spatInSituPlotHex_single = function(gobject,
 #' @param feat_type feature types of the feats
 #' @param sdimx spatial dimension x
 #' @param sdimy spatial dimension y
-#' @param binwidth numeric vector for x and y width of bins (default is 1/10 of minor axis)
+#' @param binwidth numeric vector for x and y width of bins (default is minor axis
+#' range/10, where the 10 is from \code{min_axis_bins})
+#' @param min_axis_bins number of bins to create per range defined by minor axis.
+#' (default value is 10)
 #' @param alpha alpha of hexbin plot
 #' @param show_polygon overlay polygon information (cell shape)
 #' @param polygon_feat_type feature type associated with polygon information
@@ -746,6 +751,7 @@ spatInSituPlotHex = function(gobject,
                              sdimx = 'x',
                              sdimy = 'y',
                              binwidth = NULL,
+                             min_axis_bins = 10,
                              alpha = 0.5,
                              show_polygon = TRUE,
                              polygon_feat_type = 'cell',

--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -682,7 +682,7 @@ spatInSituPlotHex_single = function(gobject,
                                    sel_feat = feat,
                                    sdimx = sdimx,
                                    sdimy = sdimy,
-                                   bins = bins)
+                                   binwidth = binwidth)
 
 
   ## adjust theme settings
@@ -789,7 +789,7 @@ spatInSituPlotHex = function(gobject,
                                   feat_type = feat_type,
                                   sdimx = sdimx,
                                   sdimy = sdimy,
-                                  bins = bins,
+                                  binwidth = binwidth,
                                   alpha = alpha,
                                   show_polygon = show_polygon,
                                   polygon_feat_type = polygon_feat_type,

--- a/R/spatial_in_situ_visuals.R
+++ b/R/spatial_in_situ_visuals.R
@@ -693,7 +693,6 @@ spatInSituPlotHex_single = function(gobject,
     plot = plot + ggplot2::coord_fixed(ratio = coord_fix_ratio)
   }
 
-
   return(plot)
 
 }
@@ -749,7 +748,7 @@ spatInSituPlotHex = function(gobject,
                              polygon_fill_as_factor = NULL,
                              polygon_alpha = 0.5,
                              polygon_size = 0.5,
-                             coord_fix_ratio = NULL,
+                             coord_fix_ratio = 1,
                              axis_text = 8,
                              axis_title = 8,
                              legend_text = 6,
@@ -803,12 +802,16 @@ spatInSituPlotHex = function(gobject,
 
   }
 
-  # combine plots with cowplot
-  combo_plot <- cowplot::plot_grid(plotlist = savelist,
-                                   ncol = cow_n_col,
-                                   rel_heights = cow_rel_h,
-                                   rel_widths = cow_rel_w,
-                                   align = cow_align)
+  if(length(savelist) == 1) {
+    combo_plot = savelist[[1]]
+  } else {
+    # combine plots with cowplot
+    combo_plot <- cowplot::plot_grid(plotlist = savelist,
+                                     ncol = cow_n_col,
+                                     rel_heights = cow_rel_h,
+                                     rel_widths = cow_rel_w,
+                                     align = cow_align)
+  }
 
 
   ## print plot
@@ -969,7 +972,6 @@ spatInSituPlotDensity_single = function(gobject,
     plot = plot + ggplot2::coord_fixed(ratio = coord_fix_ratio)
   }
 
-
   return(plot)
 
 }
@@ -1023,7 +1025,7 @@ spatInSituPlotDensity = function(gobject,
                                  polygon_fill_as_factor = NULL,
                                  polygon_alpha = 0.5,
                                  polygon_size = 0.5,
-                                 coord_fix_ratio = NULL,
+                                 coord_fix_ratio = 1,
                                  axis_text = 8,
                                  axis_title = 8,
                                  legend_text = 6,
@@ -1079,13 +1081,17 @@ spatInSituPlotDensity = function(gobject,
 
   }
 
+  if(length(savelist) == 1) {
+    combo_plot = savelist[[1]]
+  } else {
+    # combine plots with cowplot
+    combo_plot <- cowplot::plot_grid(plotlist = savelist,
+                                     ncol = cow_n_col,
+                                     rel_heights = cow_rel_h,
+                                     rel_widths = cow_rel_w,
+                                     align = cow_align)
+  }
 
-  # combine plots with cowplot
-  combo_plot <- cowplot::plot_grid(plotlist = savelist,
-                                   ncol = cow_n_col,
-                                   rel_heights = cow_rel_h,
-                                   rel_widths = cow_rel_w,
-                                   align = cow_align)
 
 
   ## print plot

--- a/man/calculateOverlapPolygonImages.Rd
+++ b/man/calculateOverlapPolygonImages.Rd
@@ -6,7 +6,7 @@
 \usage{
 calculateOverlapPolygonImages(
   gobject,
-  name_overlap = "images",
+  name_overlap = "protein",
   spatial_info = "cell",
   poly_ID_names = NULL,
   image_names = NULL,

--- a/man/filterGiotto.Rd
+++ b/man/filterGiotto.Rd
@@ -17,6 +17,10 @@ filterGiotto(
   all_spat_units = TRUE,
   all_feat_types = TRUE,
   poly_info = "cell",
+  tag_cells = FALSE,
+  tag_cell_name = "tag",
+  tag_feats = FALSE,
+  tag_feats_name = "tag",
   verbose = TRUE
 )
 }
@@ -46,6 +50,14 @@ spatial unit/feature type combination across ALL spatial units (default = TRUE)}
 spatial unit/feature type combination across ALL feature types (default = TRUE)}
 
 \item{poly_info}{polygon information to use}
+
+\item{tag_cells}{tag filtered cells in metadata vs. remove cells}
+
+\item{tag_cell_name}{column name for tagged cells in metadata}
+
+\item{tag_feats}{tag features in metadata vs. remove features}
+
+\item{tag_feats_name}{column name for tagged features in metadata}
 
 \item{verbose}{verbose}
 }

--- a/man/spatCellPlot2D.Rd
+++ b/man/spatCellPlot2D.Rd
@@ -44,7 +44,7 @@ spatCellPlot2D(
   other_cell_color = "lightgrey",
   other_point_size = 1,
   other_cells_alpha = 0.1,
-  coord_fix_ratio = NULL,
+  coord_fix_ratio = 1,
   show_legend = T,
   legend_text = 8,
   legend_symbol_size = 1,

--- a/man/spatDeconvPlot.Rd
+++ b/man/spatDeconvPlot.Rd
@@ -25,7 +25,7 @@ spatDeconvPlot(
   title = NULL,
   axis_text = 8,
   axis_title = 8,
-  coord_fix_ratio = TRUE,
+  coord_fix_ratio = 1,
   show_plot = NA,
   return_plot = NA,
   save_plot = NA,

--- a/man/spatDimCellPlot2D.Rd
+++ b/man/spatDimCellPlot2D.Rd
@@ -76,7 +76,7 @@ spatDimCellPlot2D(
   vor_alpha = 1,
   axis_text = 8,
   axis_title = 8,
-  coord_fix_ratio = NULL,
+  coord_fix_ratio = 1,
   cow_n_col = 2,
   cow_rel_h = 1,
   cow_rel_w = 1,

--- a/man/spatInSituPlotDensity.Rd
+++ b/man/spatInSituPlotDensity.Rd
@@ -18,6 +18,7 @@ spatInSituPlotDensity(
   polygon_fill_as_factor = NULL,
   polygon_alpha = 0.5,
   polygon_size = 0.5,
+  coord_fix_ratio = NULL,
   axis_text = 8,
   axis_title = 8,
   legend_text = 6,
@@ -59,6 +60,8 @@ spatInSituPlotDensity(
 \item{polygon_alpha}{alpha of polygon}
 
 \item{polygon_size}{size of polygon border}
+
+\item{coord_fix_ratio}{fix ratio between x and y-axis}
 
 \item{axis_text}{axis text size}
 

--- a/man/spatInSituPlotDensity_single.Rd
+++ b/man/spatInSituPlotDensity_single.Rd
@@ -18,6 +18,7 @@ spatInSituPlotDensity_single(
   polygon_fill_as_factor = NULL,
   polygon_alpha = 0.5,
   polygon_size = 0.5,
+  coord_fix_ratio = NULL,
   axis_text = 8,
   axis_title = 8,
   legend_text = 6,

--- a/man/spatInSituPlotHex.Rd
+++ b/man/spatInSituPlotHex.Rd
@@ -19,6 +19,7 @@ spatInSituPlotHex(
   polygon_fill_as_factor = NULL,
   polygon_alpha = 0.5,
   polygon_size = 0.5,
+  coord_fix_ratio = NULL,
   axis_text = 8,
   axis_title = 8,
   legend_text = 6,
@@ -62,6 +63,8 @@ spatInSituPlotHex(
 \item{polygon_alpha}{alpha of polygon}
 
 \item{polygon_size}{size of polygon border}
+
+\item{coord_fix_ratio}{fix ratio between x and y-axis}
 
 \item{axis_text}{axis text size}
 

--- a/man/spatInSituPlotHex_single.Rd
+++ b/man/spatInSituPlotHex_single.Rd
@@ -19,6 +19,7 @@ spatInSituPlotHex_single(
   polygon_fill_as_factor = NULL,
   polygon_alpha = 0.5,
   polygon_size = 0.5,
+  coord_fix_ratio = NULL,
   axis_text = 8,
   axis_title = 8,
   legend_text = 6,

--- a/man/spatInSituPlotPoints.Rd
+++ b/man/spatInSituPlotPoints.Rd
@@ -37,7 +37,7 @@ spatInSituPlotPoints(
   axis_text = 8,
   axis_title = 8,
   legend_text = 6,
-  coord_fix_ratio = NULL,
+  coord_fix_ratio = 1,
   background_color = "black",
   show_legend = TRUE,
   plot_method = c("ggplot", "scattermore", "scattermost"),

--- a/man/spatPlot2D_single.Rd
+++ b/man/spatPlot2D_single.Rd
@@ -47,7 +47,7 @@ spatPlot2D_single(
   other_cell_color = "lightgrey",
   other_point_size = 1,
   other_cells_alpha = 0.1,
-  coord_fix_ratio = NULL,
+  coord_fix_ratio = 1,
   title = NULL,
   show_legend = T,
   legend_text = 8,


### PR DESCRIPTION
Edits to spatial density plotting functions
`spatInSituPlotHex` 
 - replaced `bins` param with `binwidth` a numeric vector for xy which is used to set the size of the bins based on the x and y coordinate scaling. When binwidth is NULL, default behavior is to take the range of the minor axis and divide it by `min_axis_bins` param
 - added `min_axis_bins` param as a way to set how many bins to create based on the minimum axis
 - add `coord_fix_ratio`

`spatInSituPlotDensity`.
- removed ggplot warning about deprecation of `..density..`
- add `coord_fix_ratio`
