### PR TITLE
patch saveGiotto()

### DIFF
--- a/R/general_help.R
+++ b/R/general_help.R
@@ -737,6 +737,10 @@ saveGiotto = function(gobject,
       dir.create(image_dir)
 
       if(!is.null(gobject@largeImages[[image]]@raster_object)) {
+        # save extent info just in case
+        gobject@largeImages[[image]]@extent = terra::ext(gobject@largeImages[[image]]@raster_object)[]
+
+        # save raster
         filename = paste0(image_dir, '/', image, '_spatRaster')
         terra::writeRaster(x = gobject@largeImages[[image]]@raster_object, filename = filename, filetype = image_filetype)
       }

--- a/R/general_help.R
+++ b/R/general_help.R
@@ -669,10 +669,10 @@ saveGiotto = function(gobject,
   feat_info_names = list_feature_info_names(gobject)
 
   if(!is.null(feat_info_names)) {
+    feat_dir = paste0(final_dir,'/','Features')
+    dir.create(feat_dir)
     for(feat in feat_info_names) {
       if(verbose) wrap_msg('For feature: ', feat, '\n')
-      feat_dir = paste0(final_dir,'/','Features')
-      dir.create(feat_dir)
 
       # original spatvector
       if(!is.null(gobject@feat_info[[feat]]@spatVector)) {
@@ -692,12 +692,11 @@ saveGiotto = function(gobject,
   spat_info_names = list_spatial_info_names(gobject)
 
   if(!is.null(spat_info_names)) {
+    spatinfo_dir = paste0(final_dir,'/','SpatialInfo')
+    dir.create(spatinfo_dir)
     for(spatinfo in spat_info_names) {
 
       if(verbose) wrap_msg('For spatial information: ', spatinfo, '\n')
-
-      spatinfo_dir = paste0(final_dir,'/','SpatialInfo')
-      dir.create(spatinfo_dir)
 
       # original spatVectors
       if(!is.null(gobject@spatial_info[[spatinfo]]@spatVector)) {
@@ -730,11 +729,10 @@ saveGiotto = function(gobject,
   image_names = list_images_names(gobject, img_type = 'largeImage')
 
   if(!is.null(image_names)) {
+    image_dir = paste0(final_dir,'/','Images')
+    dir.create(image_dir)
     for(image in image_names) {
       if(verbose) wrap_msg('For image information: ', image, '\n')
-
-      image_dir = paste0(final_dir,'/','Images')
-      dir.create(image_dir)
 
       if(!is.null(gobject@largeImages[[image]]@raster_object)) {
         # save extent info just in case

--- a/R/general_help.R
+++ b/R/general_help.R
@@ -661,7 +661,7 @@ saveGiotto = function(gobject,
       dir.create(final_dir)
     }
   } else {
-    dir.create(final_dir)
+    dir.create(final_dir, recursive = TRUE)
   }
 
   ## save spatVector objects related to feature information

--- a/R/giotto.R
+++ b/R/giotto.R
@@ -4876,8 +4876,8 @@ joinGiottoObjects = function(gobject_list,
 
           }
 
-
-
+          # save extent info
+          gobj@largeImages[[imname]]@extent = terra::ext(gobj@largeImages[[imname]]@raster_object)[]
         }
 
         all_largeImage_list[[imname]] = gobj@largeImages[[imname]]


### PR DESCRIPTION
- Move subdirectory creation out of for-loop
- Add saving of image extent information to `saveGiotto()` and 'shift' workflow of `joinGiottoObjects()` to support compatibility with `reconnectGiottoImage()`