### PR TITLE
update initialize giotto

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -495,7 +495,24 @@ giotto <- setClass(
 #' @keywords internal
 setMethod('initialize', signature('giotto'), function(.Object, ...) {
 
-  .Object = methods::callNextMethod()
+
+  a = list(...)
+
+
+
+  ## set slots ##
+  ## --------- ##
+
+  if('spatial_info' %in% names(a)) {
+    .Object = setPolygonInfo(.Object, gpolygon = a$spatial_info)
+  }
+  if('expression' %in% names(a)) {
+    .Object = setExpression(.Object, values = a$expression)
+  }
+
+
+
+
 
   # message('initialize Giotto run\n\n')  # debug
 
@@ -770,6 +787,11 @@ setMethod('initialize', signature('giotto'), function(.Object, ...) {
 
 
 
+
+
+
+
+
 ##### * Show ####
 # Giotto class
 
@@ -1001,37 +1023,25 @@ setClass('exprObj',
 
 ## * Initialize ####
 setMethod('initialize', 'exprObj',
-          function(.Object,
-                   name = 'test',
-                   exprMat = NULL,
-                   spat_unit = 'cell',
-                   feat_type = 'rna',
-                   provenance = NULL,
-                   misc = NULL,
-                   ...) {
+          function(.Object, ...) {
+
+            # expand args
+            a = list(.Object = .Object, ...)
 
             # evaluate data
-            if(is.null(exprMat)) exprMat = matrix()
-            else {
-              # Convert matrix input to preferred format
-              exprMat = evaluate_expr_matrix(exprMat)
+            if('exprMat' %in% names(a)) {
+              exprMat = a$exprMat
+              if(is.null(exprMat)) exprMat = matrix()
+              else {
+                # Convert matrix input to preferred format
+                exprMat = evaluate_expr_matrix(exprMat)
+              }
+
+              # return to arg list
+              a$exprMat = exprMat
             }
 
-            # populate slots
-            .Object@name = name
-            .Object@exprMat = exprMat
-            .Object@spat_unit = spat_unit
-            .Object@feat_type = feat_type
-            .Object@provenance = provenance
-            .Object@misc = misc
-
-            .Object = methods::callNextMethod(.Object,
-                                              exprMat = exprMat,
-                                              spat_unit = spat_unit,
-                                              feat_type = feat_type,
-                                              misc = misc,
-                                              ...)
-            validObject(.Object)
+            .Object = do.call('methods'::'callNextMethod', a)
             .Object
           })
 
@@ -1401,41 +1411,29 @@ setClass('spatLocsObj',
 
 ## * Initialize ####
 setMethod('initialize', 'spatLocsObj',
-          function(.Object,
-                   name = 'test',
-                   coordinates = NULL,
-                   spat_unit = 'cell',
-                   provenance = NULL,
-                   misc = NULL,
-                   ...) {
+          function(.Object, ...) {
+
+            # expand args
+            a = list(.Object = .Object, ...)
 
             # evaluate data
-            if(is.null(coordinates)) {
-              coordinates = data.table::data.table(
-                sdimx = NA_real_,
-                sdimy = NA_real_,
-                cell_ID = NA_character_
-              )
-            } else {
-              coordinates = evaluate_spatial_locations(coordinates)
+            if('coordinates' %in% names(a)) {
+              coordinates = a$coordinates
+              if(is.null(coordinates)) {
+                coordinates = data.table::data.table(
+                  sdimx = NA_real_,
+                  sdimy = NA_real_,
+                  cell_ID = NA_character_
+                )
+              } else {
+                coordinates = evaluate_spatial_locations(coordinates)
+              }
+
+              # return to arg list
+              a$coordinates = coordinates
             }
 
-            # populate slots
-            .Object@name = name
-            .Object@coordinates = coordinates
-            .Object@spat_unit = spat_unit
-            .Object@provenance = provenance
-            .Object@misc = misc
-
-
-            .Object = methods::callNextMethod(.Object,
-                                              name = name,
-                                              coordinates = coordinates,
-                                              spat_unit = spat_unit,
-                                              provenance = provenance,
-                                              misc = misc,
-                                              ...)
-            validObject(.Object)
+            .Object = do.call('methods'::'callNextMethod', a)
             .Object
           })
 

--- a/R/dd.R
+++ b/R/dd.R
@@ -33,6 +33,8 @@
 #' @param set_defaults set default spat_unit and feat_type. Change to FALSE only when
 #' expression and spat_info are not expected to exist.
 #' @param copy_obj whether to deep copy/duplicate when getting the object (default = TRUE)
+#' @param initialize (default = FALSE) whether to initialize the gobject before
+#' returning
 #' @keywords internal
 NULL
 

--- a/R/general_help.R
+++ b/R/general_help.R
@@ -5,7 +5,9 @@
 #' @description guesses how many cores to use
 #' @return numeric
 #' @keywords internal
-determine_cores = function(cores, min_cores = 1, max_cores = 10) {
+determine_cores = function(cores = getOption('giotto.cores', default = NA),
+                           min_cores = 1,
+                           max_cores = 10) {
 
   if(is.na(cores) | !is.numeric(cores) | (is.numeric(cores) & cores <= 0)) {
     cores = parallel::detectCores()
@@ -16,12 +18,16 @@ determine_cores = function(cores, min_cores = 1, max_cores = 10) {
       cores = cores - 2
       cores = ifelse(cores > max_cores, max_cores, cores)
     }
+    options('giotto.cores' = cores)
     return(cores)
+
   } else {
     cores = cores
     return(cores)
   }
 }
+
+
 
 #' @title getDistinctColors
 #' @description Returns a number of distint colors based on the RGB scale

--- a/R/giotto.R
+++ b/R/giotto.R
@@ -460,15 +460,13 @@ replaceGiottoInstructions = function(gobject,
 #' @details The expression matrix needs to have both unique column names and row names
 #' @export
 readExprMatrix = function(path,
-                          cores = NA,
+                          cores = determine_cores(),
                           transpose = FALSE) {
 
   # check if path is a character vector and exists
   if(!is.character(path)) stop('path needs to be character vector')
   if(!file.exists(path)) stop('the path: ', path, ' does not exist')
 
-  # set number of cores automatically, but with limit of 10
-  cores = determine_cores(cores)
   data.table::setDTthreads(threads = cores)
 
   # read and convert
@@ -498,7 +496,7 @@ readExprMatrix = function(path,
 #' @keywords internal
 evaluate_expr_matrix = function(inputmatrix,
                                 sparse = TRUE,
-                                cores = NA) {
+                                cores = determine_cores()) {
 
 
   if(inherits(inputmatrix, 'character')) {
@@ -619,7 +617,7 @@ depth <- function(this,
 #' @keywords internal
 read_expression_data = function(expr_list = NULL,
                                 sparse = TRUE,
-                                cores = NA,
+                                cores = determine_cores(),
                                 default_feat_type = NULL,
                                 verbose = TRUE,
                                 provenance = NULL) {
@@ -1178,7 +1176,7 @@ evaluate_spatial_locations = function(spatial_locs,
 #' @keywords internal
 read_spatial_location_data = function(gobject,
                                       spat_loc_list,
-                                      cores = getOption('giotto.cores'),
+                                      cores = determine_cores(),
                                       provenance = NULL,
                                       verbose = TRUE) {
 
@@ -1772,7 +1770,7 @@ read_nearest_networks = function(gobject,
 #' @return data.table
 #' @keywords internal
 evaluate_spatial_info = function(spatial_info,
-                                 cores = 1,
+                                 cores = determine_cores(),
                                  spatial_locs) {
 
 
@@ -1841,7 +1839,7 @@ evaluate_spatial_info = function(spatial_info,
 #' @keywords internal
 evaluate_feat_info = function(spatial_feat_info,
                               feat_type,
-                              cores = 1,
+                              cores = determine_cores(),
                               feat_ID) {
 
 
@@ -1981,7 +1979,7 @@ createGiottoObject <- function(expression,
                                largeImages = NULL,
                                offset_file = NULL,
                                instructions = NULL,
-                               cores = NA,
+                               cores = determine_cores(),
                                verbose = TRUE) {
 
   # create minimum giotto
@@ -2036,7 +2034,6 @@ createGiottoObject <- function(expression,
 
 
   ## if cores is not set, then set number of cores automatically, but with limit of 10
-  cores = determine_cores(cores)
   data.table::setDTthreads(threads = cores)
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,7 +19,6 @@
   if(isTRUE(check_core)) {
     cores = determine_cores(cores = NA)
     data.table::setDTthreads(threads = cores)
-    options('giotto.cores' = cores)
     options('giotto.check_core' = FALSE)
   }
 

--- a/man/createGiottoObject.Rd
+++ b/man/createGiottoObject.Rd
@@ -23,7 +23,7 @@ createGiottoObject(
   largeImages = NULL,
   offset_file = NULL,
   instructions = NULL,
-  cores = NA,
+  cores = determine_cores(),
   verbose = TRUE
 )
 }

--- a/man/determine_cores.Rd
+++ b/man/determine_cores.Rd
@@ -4,7 +4,11 @@
 \alias{determine_cores}
 \title{determine_cores}
 \usage{
-determine_cores(cores, min_cores = 1, max_cores = 10)
+determine_cores(
+  cores = getOption("giotto.cores", default = NA),
+  min_cores = 1,
+  max_cores = 10
+)
 }
 \value{
 numeric

--- a/man/evaluate_expr_matrix.Rd
+++ b/man/evaluate_expr_matrix.Rd
@@ -4,7 +4,7 @@
 \alias{evaluate_expr_matrix}
 \title{Evaluate expression matrix}
 \usage{
-evaluate_expr_matrix(inputmatrix, sparse = TRUE, cores = NA)
+evaluate_expr_matrix(inputmatrix, sparse = TRUE, cores = determine_cores())
 }
 \arguments{
 \item{inputmatrix}{inputmatrix to evaluate}

--- a/man/evaluate_feat_info.Rd
+++ b/man/evaluate_feat_info.Rd
@@ -4,7 +4,12 @@
 \alias{evaluate_feat_info}
 \title{Evaluate feature info}
 \usage{
-evaluate_feat_info(spatial_feat_info, feat_type, cores = 1, feat_ID)
+evaluate_feat_info(
+  spatial_feat_info,
+  feat_type,
+  cores = determine_cores(),
+  feat_ID
+)
 }
 \arguments{
 \item{spatial_feat_info}{spatial feature information to evaluate}

--- a/man/evaluate_spatial_info.Rd
+++ b/man/evaluate_spatial_info.Rd
@@ -4,7 +4,7 @@
 \alias{evaluate_spatial_info}
 \title{Evaluate spatial info}
 \usage{
-evaluate_spatial_info(spatial_info, cores = 1, spatial_locs)
+evaluate_spatial_info(spatial_info, cores = determine_cores(), spatial_locs)
 }
 \arguments{
 \item{spatial_info}{spatial information to evaluate}

--- a/man/evaluate_spatial_locations.Rd
+++ b/man/evaluate_spatial_locations.Rd
@@ -4,7 +4,7 @@
 \alias{evaluate_spatial_locations}
 \title{Evaluate spatial locations}
 \usage{
-evaluate_spatial_locations(spatial_locs, cores = 1)
+evaluate_spatial_locations(spatial_locs, cores = getOption("giotto.cores"))
 }
 \arguments{
 \item{spatial_locs}{spatial locations to evaluate}

--- a/man/readExprMatrix.Rd
+++ b/man/readExprMatrix.Rd
@@ -4,7 +4,7 @@
 \alias{readExprMatrix}
 \title{Read expression matrix}
 \usage{
-readExprMatrix(path, cores = NA, transpose = FALSE)
+readExprMatrix(path, cores = determine_cores(), transpose = FALSE)
 }
 \arguments{
 \item{path}{path to the expression matrix}

--- a/man/read_expression_data.Rd
+++ b/man/read_expression_data.Rd
@@ -7,7 +7,7 @@
 read_expression_data(
   expr_list = NULL,
   sparse = TRUE,
-  cores = NA,
+  cores = determine_cores(),
   default_feat_type = NULL,
   verbose = TRUE,
   provenance = NULL

--- a/man/read_spatial_location_data.Rd
+++ b/man/read_spatial_location_data.Rd
@@ -7,7 +7,7 @@
 read_spatial_location_data(
   gobject,
   spat_loc_list,
-  cores = 1,
+  cores = determine_cores(),
   provenance = NULL,
   verbose = TRUE
 )

--- a/man/setSpatialLocations.Rd
+++ b/man/setSpatialLocations.Rd
@@ -8,7 +8,7 @@ setSpatialLocations(
   gobject,
   spatlocs,
   spat_unit = NULL,
-  spat_loc_name = "raw",
+  name = "raw",
   provenance = NULL,
   verbose = TRUE,
   set_defaults = TRUE
@@ -22,14 +22,14 @@ setSpatialLocations(
 
 \item{spat_unit}{spatial unit (e.g. "cell")}
 
-\item{spat_loc_name}{name of spatial locations, default "raw"}
-
 \item{provenance}{provenance information (optional)}
 
 \item{verbose}{be verbose}
 
 \item{set_defaults}{set default spat_unit and feat_type. Change to FALSE only when
 expression and spat_info are not expected to exist.}
+
+\item{spat_loc_name}{name of spatial locations, default "raw"}
 }
 \value{
 giotto object

--- a/man/set_dimReduction.Rd
+++ b/man/set_dimReduction.Rd
@@ -14,7 +14,8 @@ set_dimReduction(
   name = "pca",
   provenance = NULL,
   verbose = TRUE,
-  set_defaults = TRUE
+  set_defaults = TRUE,
+  initialize = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ set_dimReduction(
 
 \item{set_defaults}{set default spat_unit and feat_type. Change to FALSE only when
 expression and spat_info are not expected to exist.}
+
+\item{initialize}{(default = FALSE) whether to initialize the gobject before
+returning}
 }
 \value{
 giotto object

--- a/man/set_expression_values.Rd
+++ b/man/set_expression_values.Rd
@@ -12,7 +12,8 @@ set_expression_values(
   name = "test",
   provenance = NULL,
   verbose = TRUE,
-  set_defaults = TRUE
+  set_defaults = TRUE,
+  initialize = FALSE
 )
 }
 \arguments{
@@ -32,6 +33,9 @@ set_expression_values(
 
 \item{set_defaults}{set default spat_unit and feat_type. Change to FALSE only when
 expression and spat_info are not expected to exist.}
+
+\item{initialize}{(default = FALSE) whether to initialize the gobject before
+returning. Will be set to TRUE when called by the external}
 }
 \value{
 giotto object

--- a/man/set_spatial_locations.Rd
+++ b/man/set_spatial_locations.Rd
@@ -11,7 +11,8 @@ set_spatial_locations(
   spat_loc_name = "raw",
   provenance = NULL,
   verbose = TRUE,
-  set_defaults = TRUE
+  set_defaults = TRUE,
+  initialize = FALSE
 )
 }
 \arguments{
@@ -30,6 +31,9 @@ set_spatial_locations(
 
 \item{set_defaults}{set default spat_unit and feat_type. Change to FALSE only when
 expression and spat_info are not expected to exist.}
+
+\item{initialize}{(default = FALSE) whether to initialize the gobject before
+returning}
 }
 \value{
 giotto object


### PR DESCRIPTION
- internal setters no longer call initialize by default
- externals will call internals to set and then initialize
- initialize functions for exprObj and spatLocsObj rewritten to take advantage of evaluate functions and validity checks