### PR TITLE
hotflix: spatplot2D() plotting of metadata

### DIFF
--- a/R/auxiliary_giotto.R
+++ b/R/auxiliary_giotto.R
@@ -4822,7 +4822,7 @@ combineMetadata = function(gobject,
   cell_ID = NULL
 
   if(!is.null(spatial_locs)) {
-    metadata = cbind(metadata, spatial_locs[, cell_ID := NULL])
+    metadata = merge(metadata, spatial_locs, by = 'cell_ID')
   }
 
 


### PR DESCRIPTION
Fix `combineMetadata()` which was using a cbind instead of merge, causing the plotted metadata clustering information to be out of sync.