### PR TITLE
Fix: `doClusterProjection()`

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -2940,6 +2940,12 @@ doClusterProjection = function(target_gobject,
   # package check for dendextend
   package_check(pkg_name = "FNN", repository = "CRAN")
 
+  spat_unit = set_default_spat_unit(gobject = target_gobject,
+                                    spat_unit = spat_unit)
+  feat_type = set_default_feat_type(gobject = target_gobject,
+                                    spat_unit = spat_unit,
+                                    feat_type = feat_type)
+
   # identify clusters from source object and create annotation vector
   cell_meta_source = get_cell_metadata(gobject = source_gobject,
                                        spat_unit = spat_unit,
@@ -3026,11 +3032,15 @@ doClusterProjection = function(target_gobject,
       prob_label = paste0(target_cluster_label_name,'_prob')
 
       target_gobject = addCellMetadata(gobject = target_gobject,
+                                       spat_unit = spat_unit,
+                                       feat_type = feat_type,
                                        new_metadata = cell_meta_target[, c('cell_ID', target_cluster_label_name, prob_label), with = FALSE],
                                        by_column = TRUE,
                                        column_cell_ID = 'cell_ID')
     } else {
       target_gobject = addCellMetadata(gobject = target_gobject,
+                                       spat_unit = spat_unit,
+                                       feat_type = feat_type,
                                        new_metadata = cell_meta_target[, c('cell_ID', target_cluster_label_name), with = FALSE],
                                        by_column = TRUE,
                                        column_cell_ID = 'cell_ID')

--- a/man/createMerscopeLargeImage.Rd
+++ b/man/createMerscopeLargeImage.Rd
@@ -7,14 +7,14 @@
 createMerscopeLargeImage(image_file, transforms_file, name = "image")
 }
 \arguments{
-\item{image_file}{character. Path to image file to load or list of multiple
-such paths.}
+\item{image_file}{character. Path to one or more MERSCOPE images to load}
 
 \item{transforms_file}{character. Path to MERSCOPE transforms file. Usually
 in the same folder as the images and named
 'micron_to_mosaic_pixel_transform.csv'}
 
-\item{name}{name to assign the image}
+\item{name}{character. name to assign the image. Multiple should be provided
+if image_file is a list.}
 }
 \description{
 Read MERSCOPE stitched images as giottoLargeImage. Images will also be


### PR DESCRIPTION
- Fix: issue where `doClusterProjection()` ignores the spat_unit and feat_type when writing projected results to metadata