### PR TITLE
fix: `interpolateFeatures()` incompatibility with certain characters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
-# Giotto 4.0.10 TBD
+# Giotto 4.1.0 TBD
 
 ## Bug fixes
 * Fix error in `plotInteractivePolygons()` when providing a spatial plot with a continuous scale [#964](https://github.com/drieslab/Giotto/issues/964) by jweis3
 * Fix error in DWLS `find_dampening_constant()` when `S[subset, ]` produces only 1 gene.
 
 ## New
-* `read10xAffineImage()` for reading 10x affine tranformed images
+* `read10xAffineImage()` for reading 10x affine transformed images
+* Several modular importer functions
 
 # Giotto 4.0.9
 

--- a/R/kriging.R
+++ b/R/kriging.R
@@ -190,7 +190,7 @@ setMethod(
                 function(feat) {
                     name <- sprintf(name_fmt, feat)
                     filename <- file.path(savedir, paste0(name, ".tif"))
-
+browser()
                     # create subset table with only relevant data
                     data <-
                         annotatedlocs[, c("cell_ID", feat, "sdimx", "sdimy")]

--- a/R/kriging.R
+++ b/R/kriging.R
@@ -191,10 +191,15 @@ setMethod(
                     name <- sprintf(name_fmt, feat)
                     filename <- file.path(savedir, paste0(name, ".tif"))
 
+                    # create subset table with only relevant data
+                    data <-
+                        annotatedlocs[, c("cell_ID", feat, "sdimx", "sdimy")]
+                    data.table::setnames(data, old = feat, new = "count")
+
                     # model to use
                     model <- gstat::gstat(
                         id = feat,
-                        formula = as.formula(sprintf("`%s` ~ 1", feat)),
+                        formula = count ~ 1,
                         locations = ~ sdimx + sdimy,
                         data = annotatedlocs,
                         nmax = 7,

--- a/R/kriging.R
+++ b/R/kriging.R
@@ -192,8 +192,9 @@ setMethod(
                     filename <- file.path(savedir, paste0(name, ".tif"))
 
                     # create subset table with only relevant data
-                    data <-
-                        annotatedlocs[, c("cell_ID", feat, "sdimx", "sdimy")]
+                    data <- annotatedlocs[,
+                        c("cell_ID", feat, "sdimx", "sdimy"), with = FALSE
+                    ]
                     data.table::setnames(data, old = feat, new = "count")
 
                     # model to use

--- a/R/kriging.R
+++ b/R/kriging.R
@@ -190,7 +190,7 @@ setMethod(
                 function(feat) {
                     name <- sprintf(name_fmt, feat)
                     filename <- file.path(savedir, paste0(name, ".tif"))
-browser()
+
                     # create subset table with only relevant data
                     data <-
                         annotatedlocs[, c("cell_ID", feat, "sdimx", "sdimy")]
@@ -201,7 +201,7 @@ browser()
                         id = feat,
                         formula = count ~ 1,
                         locations = ~ sdimx + sdimy,
-                        data = annotatedlocs,
+                        data = data,
                         nmax = 7,
                         set = list(
                             idp = 0.5


### PR DESCRIPTION
- Fix error in `interpolateFeatures()` where feature names with `-` or starting with numbers did not work