### PR TITLE
Giotto 4.1.4 - hotfix visium spot polygon sizing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Giotto
 Title: Spatial Single-Cell Transcriptomics Toolbox
-Version: 4.1.3
+Version: 4.1.4
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7650-7754")),
@@ -108,10 +108,6 @@ Suggests:
     trendsceek,
     testthat (>= 3.0.0),
     rmarkdown
-Remotes:
-    drieslab/GiottoUtils,
-    drieslab/GiottoClass,
-    drieslab/GiottoVisuals
 Collate:
     'ONTraC_wrapper.R'
     'auxiliary_giotto.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -108,6 +108,10 @@ Suggests:
     trendsceek,
     testthat (>= 3.0.0),
     rmarkdown
+Remotes:
+    drieslab/GiottoUtils,
+    drieslab/GiottoClass,
+    drieslab/GiottoVisuals
 Collate:
     'ONTraC_wrapper.R'
     'auxiliary_giotto.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 
 ## Changes
 * apply a modifier of 0.8461538 to visium spot diameter to reflect actual spot size
+* deprecate param `resolution_parameter` in favor of `resolution` for `doLeidenClusterIgraph()`
 
 # Giotto 4.1.3 (2024/10/27)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
 
-# Giotto 4.1.4
+# Giotto 4.1.4 (2024/10/30)
 
 ## Changes
-* apply a modifier of 0.8461538 to visium spot diameter to reflect actual spot size
-* deprecate param `resolution_parameter` in favor of `resolution` for `doLeidenClusterIgraph()`
+* `createGiottoVisiumObject()` apply a modifier of 0.8461538 to visium spot diameter to reflect actual spot size
+* `doLeidenClusterIgraph()` deprecate param `resolution_parameter` in favor of `resolution`
+
+## Enhancements
+* `createGiottoVisiumObject()` append multiplicative scalefactor to get micron 
+  values from the current coordinate units during Visium object creation. 
+  Accessible through `instructions(gobject, "micron_scale")`
 
 # Giotto 4.1.3 (2024/10/27)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+
+# Giotto 4.1.4
+
+## Changes
+* apply a modifier of 0.8461538 to visium spot diameter to reflect actual spot size
+
 # Giotto 4.1.3 (2024/10/27)
 
 ## New

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -237,7 +237,8 @@ doLeidenCluster <- function(gobject,
 #' @param network_name name of NN network to use, default to "sNN.pca"
 #' @param objective_function objective function for the leiden algo
 #' @param weights weights of edges
-#' @param resolution_parameter resolution, default = 1
+#' @param resolution resolution, default = 1
+#' @param resolution_parameter deprecated. Use `resolution` instead
 #' @param beta leiden randomness
 #' @param initial_membership initial membership of cells for the partition
 #' @param n_iterations number of interations to run the Leiden algorithm.
@@ -246,6 +247,7 @@ doLeidenCluster <- function(gobject,
 #' @param seed_number number for seed
 #' @inheritDotParams igraph::cluster_leiden -graph -objective_function
 #' -resolution_parameter -beta -weights -initial_membership -n_iterations
+#' -resolution
 #' @returns giotto object with new clusters appended to cell metadata
 #' @details
 #' This function is a wrapper for the Leiden algorithm implemented in igraph,
@@ -270,7 +272,8 @@ doLeidenClusterIgraph <- function(gobject,
     network_name = "sNN.pca",
     objective_function = c("modularity", "CPM"),
     weights = NULL,
-    resolution_parameter = 1,
+    resolution = 1,
+    resolution_parameter = deprecated(),
     beta = 0.01,
     initial_membership = NULL,
     n_iterations = 1000,
@@ -287,6 +290,13 @@ doLeidenClusterIgraph <- function(gobject,
         gobject = gobject,
         spat_unit = spat_unit,
         feat_type = feat_type
+    )
+    
+    resolution <- deprecate_param(
+        x = resolution_parameter, 
+        y = resolution,
+        fun = "doLeidenClusterIgraph",
+        when = "4.1.4"
     )
 
     ## get cell IDs ##
@@ -321,7 +331,7 @@ doLeidenClusterIgraph <- function(gobject,
     leiden_clusters <- igraph::cluster_leiden(
         graph = graph_object_undirected,
         objective_function = objective_function,
-        resolution_parameter = resolution_parameter,
+        resolution = resolution,
         beta = beta,
         weights = weights,
         initial_membership = initial_membership,

--- a/R/convenience_general.R
+++ b/R/convenience_general.R
@@ -782,9 +782,11 @@ addVisiumPolygons <- function(
     if (inherits(spatlocs, "spatLocsObj")) {
         spatlocs <- spatlocs[]
     }
+    
+    spot_adj <- 55 / 65
 
     vis_spot_poly <- GiottoClass::circleVertices(
-        radius = json_scalefactors$spot_diameter_fullres / 2
+        radius = json_scalefactors$spot_diameter_fullres / 2 * spot_adj
     )
 
     GiottoClass::polyStamp(

--- a/R/convenience_general.R
+++ b/R/convenience_general.R
@@ -511,6 +511,9 @@ createGiottoVisiumObject <- function(
             verbose = FALSE,
             initialize = TRUE
         )
+        
+        ms <- 65 / json_info$spot_diameter_fullres
+        instructions(giotto_object, "micron_scale") <- ms
     }
 
     return(giotto_object)
@@ -786,7 +789,8 @@ addVisiumPolygons <- function(
     spot_adj <- 55 / 65
 
     vis_spot_poly <- GiottoClass::circleVertices(
-        radius = json_scalefactors$spot_diameter_fullres / 2 * spot_adj
+        radius = json_scalefactors$spot_diameter_fullres / 2 * spot_adj,
+        npoints = 100
     )
 
     GiottoClass::polyStamp(

--- a/man/doLeidenClusterIgraph.Rd
+++ b/man/doLeidenClusterIgraph.Rd
@@ -13,7 +13,8 @@ doLeidenClusterIgraph(
   network_name = "sNN.pca",
   objective_function = c("modularity", "CPM"),
   weights = NULL,
-  resolution_parameter = 1,
+  resolution = 1,
+  resolution_parameter = deprecated(),
   beta = 0.01,
   initial_membership = NULL,
   n_iterations = 1000,
@@ -41,7 +42,9 @@ doLeidenClusterIgraph(
 
 \item{weights}{weights of edges}
 
-\item{resolution_parameter}{resolution, default = 1}
+\item{resolution}{resolution, default = 1}
+
+\item{resolution_parameter}{deprecated. Use `resolution` instead}
 
 \item{beta}{leiden randomness}
 


### PR DESCRIPTION
## Changes
* `createGiottoVisiumObject()` apply a modifier of 0.8461538 to visium spot diameter to reflect actual spot size
* `doLeidenClusterIgraph()` deprecate param `resolution_parameter` in favor of `resolution`

## Enhancements
* `createGiottoVisiumObject()` append multiplicative scalefactor to get micron 
  values from the current coordinate units during Visium object creation. 
  Accessible through `instructions(gobject, "micron_scale")`