### PR TITLE
Fix cosmx_fov_shift bug convenience_cosmx.R

### DIFF
--- a/R/convenience_cosmx.R
+++ b/R/convenience_cosmx.R
@@ -667,7 +667,6 @@ setMethod("$<-", signature("CosmxReader"), function(x, name, value) {
     if (is.null(path)) return(NULL) # return early (empty case)
     fov_shifts <- data.table::fread(path)
     fs_colnames <- colnames(fov_shifts)
-    if (!"X_mm" %in% fs_colnames) return(NULL) # return early (WTX)
     
     offset_colnames <- c("fov", "x", "y")
     


### PR DESCRIPTION
Removed a line that was causing the function to always return NULL; "X_mm" can't be in fov_shifts table because the if-else statement below won't accept it, but if isn't in the table then it returns NULL early.