### PR TITLE
Fix filtering condition for top feature scores

### DIFF
--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -614,7 +614,7 @@ findGiniMarkers <- function(
     top_feats_scores <- aggr_sc[comb_rank <= min_feats | (
         expression_rank <= rank_score & detection_rank <= rank_score)]
     top_feats_scores_filtered <- top_feats_scores[comb_rank <= min_feats | (
-        expression > min_expr_gini_score & detection > min_det_gini_score)]
+        expression_gini > min_expr_gini_score & detection_gini > min_det_gini_score)]
     setorder(top_feats_scores_filtered, cluster, comb_rank)
 
 


### PR DESCRIPTION
min_expr_gini_score and min_det_gini_score parameters are thresholds on gini coefficients according to documentation, but they are compared with expression averages. This fix makes the situation coherent with the function documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect filtering condition in marker feature selection that was comparing raw aggregated values against Gini score thresholds instead of using computed Gini scores. This ensures accurate identification of top marker features in differential expression analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->