### PR TITLE
fix: correct cellBorder polygon y-transform to match spatloc negation

### DIFF
--- a/R/convenience_stereoseq.r
+++ b/R/convenience_stereoseq.r
@@ -1008,10 +1008,11 @@ setMethod("$<-", signature("StereoSeqReader"), function(x, name, value) {
     dt[, y := cell$y[cell_idx] + by]
 
     if (isTRUE(negative_y)) {
-        # shift y down by the full image height so polygons align with the
-        # negated gef spatial locations (same transform as .stereoseq_mask)
-        ymax <- max(dt$y)
-        dt[, y := y - ymax]
+        # Negate y to match the spatloc convention (0 - y_gef), identical to
+        # how .stereoseq_build_spatlocs() transforms GEF cell coordinates.
+        # y_gef increases downward from 0 at top; negation places origin at
+        # top-left with y in (-max_y, 0].
+        dt[, y := 0L - y]
     }
 
     # close each polygon by appending its first point


### PR DESCRIPTION
Use 0L - y (pure negation) instead of y - ymax. The GEF y coordinate increases downward from 0 at the top, so negation maps polygons to the same coordinate space as spatLocsObj (also 0 - y_gef). The old shift y - ymax placed polygons at y in [-range, 0] instead of [-max_gef, 0], causing misalignment with cell spatial locations.