### PR TITLE
perf: skip use_parallel for IterableMatrix in covGroups/covLoess HVF

### DIFF
--- a/R/variable_genes.R
+++ b/R/variable_genes.R
@@ -725,7 +725,11 @@ setMethod("analyzeData",
         nr_groups <- param$nr_expression_groups
         det_thresh <- param$detection_threshold
 
-        calc_fun <- if (isTRUE(param$use_parallel)) {
+        # BPCells already streams in C++ with internal threading; R-level
+        # chunking via future_lapply re-opens the file per worker and is a
+        # net loss for IterableMatrix.
+        calc_fun <- if (isTRUE(param$use_parallel) &&
+                        !inherits(x, "IterableMatrix")) {
             .calc_expr_cov_stats_parallel
         } else {
             .calc_expr_cov_stats
@@ -760,7 +764,11 @@ setMethod("analyzeData",
         pred_cov <- cov_diff <- NULL
         det_thresh <- param$detection_threshold
 
-        calc_fun <- if (isTRUE(param$use_parallel)) {
+        # BPCells already streams in C++ with internal threading; R-level
+        # chunking via future_lapply re-opens the file per worker and is a
+        # net loss for IterableMatrix.
+        calc_fun <- if (isTRUE(param$use_parallel) &&
+                        !inherits(x, "IterableMatrix")) {
             .calc_expr_cov_stats_parallel
         } else {
             .calc_expr_cov_stats


### PR DESCRIPTION
## Summary

For `analyzeData(covGroupsParam)` and `analyzeData(covLoessParam)` on an `IterableMatrix` (BPCells) backend, force the sequential `.calc_expr_cov_stats` path instead of `.calc_expr_cov_stats_parallel` regardless of the `use_parallel` flag.

BPCells already streams in C++ with internal threading; the R-level chunking in `.calc_expr_cov_stats_parallel` re-opens the matrix per worker and is a net loss for IM.

Mirrors the `varParam` IM short-circuit already present in `analyzeData(varParam)` at [variable_genes.R:803-806](https://github.com/giotto-suite/Giotto/blob/gsource/R/variable_genes.R#L803-L806) which bypasses `use_parallel` entirely.

When this hits: `calculateHVF` automatically sets `use_parallel = TRUE` if the user has set a non-sequential `future::plan()` upstream — common in parallel pipelines. Without this guard, IM would silently take the slower per-worker re-open path.

## Test plan

- [ ] R CMD check passes
- [ ] `calculateHVF(g, method = "cov_groups")` on a BPCells-backed gobject runs sequentially even when `future::plan(multisession)` is active
- [ ] Non-IM backends (dgCMatrix, DelayedArray, dense) still use the parallel path when requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)