### PR TITLE
Merge suite_dev into gsource

### DIFF
--- a/R/variable_genes.R
+++ b/R/variable_genes.R
@@ -108,8 +108,11 @@
     # NSE vars
     var <- selected <- NULL
 
-    if (!isTRUE(use_parallel)) {
-        test <- apply(X = scaled_matrix, MARGIN = 1, FUN = function(x) var(x))
+    if (!isTRUE(use_parallel) || inherits(
+        scaled_matrix,
+        c("DelayedArray", "Matrix", "dbMatrix")
+    )) {
+        test <- .rowVars_flex(scaled_matrix)
     } else {
         test <- future.apply::future_apply(
             X = scaled_matrix, MARGIN = 1, FUN = function(x) var(x),
@@ -161,6 +164,24 @@
     } else {
         # Standard matrix - use matrixStats
         return(matrixStats::rowSds(as.matrix(mymatrix), ...))
+    }
+}
+
+
+# Vectorized rowVars helper following flex function convention from GiottoClass
+.rowVars_flex <- function(mymatrix, ...) {
+    if (inherits(mymatrix, "DelayedArray")) {
+        return(DelayedMatrixStats::rowVars(mymatrix, ...))
+    } else if (inherits(mymatrix, "dgCMatrix")) {
+        return(sparseMatrixStats::rowVars(mymatrix, ...))
+    } else if (inherits(mymatrix, "Matrix")) {
+        # For other Matrix types, use sparseMatrixStats
+        return(sparseMatrixStats::rowVars(as(mymatrix, "dgCMatrix"), ...))
+    } else if (inherits(mymatrix, "dbMatrix")) {
+        # dbMatrix exports rowVars via MatrixGenerics
+        return(dbMatrix::rowVars(mymatrix))
+    } else {
+        return(apply(mymatrix, 1, stats::var, ...))
     }
 }
 

--- a/tests/testthat/test_01_processing.R
+++ b/tests/testthat/test_01_processing.R
@@ -67,6 +67,33 @@ test_that("highly variable gene detections - pearson resid", {
     checkmate::expect_character(fDataDT(g)$hvf)
 })
 
+test_that("var_p_resid row variance matches base variance on Giotto matrices", {
+    rlang::local_options(lifecycle_verbosity = "quiet")
+
+    g_var <- normalizeGiotto(
+        gobject = g,
+        feat_type = "rna",
+        scalefactor = 5000,
+        verbose = FALSE,
+        norm_methods = "pearson_resid",
+        update_slot = "pearson"
+    )
+
+    pearson_mat <- getExpression(
+        g_var,
+        spat_unit = "cell",
+        feat_type = "rna",
+        values = "pearson",
+        output = "matrix"
+    )
+
+    expect_equal(
+        .rowVars_flex(pearson_mat),
+        apply(pearson_mat, 1, stats::var),
+        tolerance = 1e-12
+    )
+})
+
 
 # statistics ####
 


### PR DESCRIPTION
## Summary

Brings suite_dev history into gsource so the branch graph reflects the intended superset relationship — closes the drift created when PR #1260 was merged to suite_dev but not propagated to gsource.

## Conflict resolution

- **\`ebc069bae\` perf: use sparse-aware row variance in var_p_resid HVF** — **superseded**. The \`.calc_var_hvf\` function it modified was removed in the \`analyzeData(varParam)\` dispatch refactor on gsource. The new dispatch ([variable_genes.R:803-806](https://github.com/giotto-suite/Giotto/blob/gsource/R/variable_genes.R#L803-L806)) already implements the same intent: IM short-circuit via \`BPCells::rowVars\`, and structured-sparse backends via \`.rowVars_flex\`. The perf benefit Eddie introduced is preserved by the refactor.
- **\`7de812377\` test: cover var_p_resid row variance equivalence** — **kept**. Tests \`.rowVars_flex\` against \`apply(., 1, stats::var)\`, which remains valid on gsource. Adds to \`tests/testthat/test_01_processing.R\`.

## Test plan

- [ ] R CMD check passes
- [ ] The new test \`var_p_resid row variance matches base variance on Giotto matrices\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)