### PR TITLE
deprecate: expression_matrix_class param + drop dead internal usages

### DIFF
--- a/R/convenience_general.R
+++ b/R/convenience_general.R
@@ -284,8 +284,8 @@ NULL
 #' \code{\link[GiottoClass]{createGiottoInstructions}}
 #' @param cores how many cores or threads to use to read data if paths are
 #' provided
-#' @param expression_matrix_class class of expression matrix to use
-#' (e.g. "dgCMatrix", "DelayedArray")
+#' @param expression_matrix_class deprecated. See
+#'   [GiottoClass::createExprObj] for details
 #' @param h5_file optional path to create an on-disk h5 file
 #' @param verbose be verbose
 #'
@@ -330,7 +330,7 @@ createGiottoVisiumObject <- function(visium_dir = NULL,
     ymax_adj = 0, # deprecated
     ymin_adj = 0, # deprecated
     instructions = NULL,
-    expression_matrix_class = c("dgCMatrix", "DelayedArray"),
+    expression_matrix_class = deprecated(),
     h5_file = NULL,
     cores = NA,
     verbose = NULL) {
@@ -347,6 +347,14 @@ createGiottoVisiumObject <- function(visium_dir = NULL,
         ymax_adj != 0 ||
         ymin_adj != 0) {
         stop(wrap_txt(img_dep_msg))
+    }
+
+    if (!missing(expression_matrix_class)) {
+        deprecate_warn(
+            "4.2.5",
+            "createGiottoVisiumObject(expression_matrix_class)",
+            details = "See `?GiottoClass::createExprObj` for details."
+        )
     }
 
     # set number of cores automatically, but with limit of 10
@@ -376,7 +384,6 @@ createGiottoVisiumObject <- function(visium_dir = NULL,
 
     # additional args to pass to object creation
     argslist$verbose <- verbose
-    argslist$expression_matrix_class <- expression_matrix_class
     argslist$h5_file <- h5_file
     argslist$instructions <- instructions
 
@@ -401,7 +408,6 @@ createGiottoVisiumObject <- function(visium_dir = NULL,
         scale_json_path = NULL,
         png_name = NULL,
         instructions = NULL,
-        expression_matrix_class = c("dgCMatrix", "DelayedArray"),
         h5_file = NULL,
         verbose = NULL) {
     # NSE vars

--- a/R/dimension_reduction.R
+++ b/R/dimension_reduction.R
@@ -3563,11 +3563,10 @@ runIterativeLSI <- function(
     
     # ---- TF-IDF and SVD on Subsampled Data ----
     sub_mat_exprobj <- createExprObj(
-      sub_mat, 
-      name = "raw", 
-      spat_unit = "cell", 
-      feat_type = feat_type,
-      expression_matrix_class = "dgCMatrix"
+      sub_mat,
+      name = "raw",
+      spat_unit = "cell",
+      feat_type = feat_type
     )
     mini_g <- giotto(instructions = instrs)
     mini_g <- setExpression(mini_g, sub_mat_exprobj, spat_unit = "cell", feat_type = feat_type)
@@ -3625,11 +3624,10 @@ runIterativeLSI <- function(
     full_mat <- mat[feats, , drop = FALSE]
     vmsg(.v = verbose, "Normalizing full matrix with TF-IDF for projection")
     full_mat_exprobj <- createExprObj(
-      full_mat, 
-      name = "raw", 
-      spat_unit = "cell", 
-      feat_type = feat_type,
-      expression_matrix_class = "dgCMatrix"
+      full_mat,
+      name = "raw",
+      spat_unit = "cell",
+      feat_type = feat_type
     )
     projected_g <- setExpression(projected_g, full_mat_exprobj, spat_unit = "cell", feat_type = feat_type)
     projected_g <- processExpression(projected_g, 

--- a/man/createGiottoVisiumObject.Rd
+++ b/man/createGiottoVisiumObject.Rd
@@ -20,7 +20,7 @@ createGiottoVisiumObject(
   ymax_adj = 0,
   ymin_adj = 0,
   instructions = NULL,
-  expression_matrix_class = c("dgCMatrix", "DelayedArray"),
+  expression_matrix_class = deprecated(),
   h5_file = NULL,
   cores = NA,
   verbose = NULL
@@ -59,8 +59,8 @@ autoscaling looks for matches in the filename for either "hires" or "lowres"}
 \item{instructions}{list of instructions or output result from
 \code{\link[GiottoClass]{createGiottoInstructions}}}
 
-\item{expression_matrix_class}{class of expression matrix to use
-(e.g. "dgCMatrix", "DelayedArray")}
+\item{expression_matrix_class}{deprecated. See
+[GiottoClass::createExprObj] for details}
 
 \item{h5_file}{optional path to create an on-disk h5 file}
 


### PR DESCRIPTION
Companion to GiottoClass PR #372 (merged), which deprecated \`expression_matrix_class\` across \`createGiottoObject\` / \`readExprData\` / \`readExprMatrix\` / \`createExprObj\`. Giotto's call sites still passed real values, which now trigger the deprecation warning on every default Visium load and on internal createExprObj calls inside the LSI dim-reduction pipeline.

## What changes

- **\`createGiottoVisiumObject\`** (R/convenience_general.R): default → \`lifecycle::deprecated()\`, warns via \`deprecate_warn\` when supplied. Param is no longer forwarded into the internal \`.visium_create\`. Matches the existing \`createGiottoCosMxObject\` deprecation pattern.
- **\`.visium_create\`** (internal): drops the \`expression_matrix_class\` param entirely. The signature accepted it but the function body never used it — dead code.
- **\`dimension_reduction.R\`**: drops the explicit \`expression_matrix_class = \"dgCMatrix\"\` argument from two \`createExprObj\` calls in the LSI sub-matrix / full-matrix path. \"dgCMatrix\" is the default class anyway; passing it explicitly now matches \`is_present()\` in GiottoClass and emits the deprecation warning.

## Test plan

- [x] Package loads via \`devtools::load_all\` without parse errors.
- [x] \`createGiottoVisiumObject\` signature carries the \`deprecated()\` sentinel.
- [x] Existing visium tests (\`tests/testthat/test_98_visium.R\`) don't pass \`expression_matrix_class\` — they call with defaults, so the deprecation won't fire incidentally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)