### PR TITLE
fix: Leiden on disk-backed networks; forward expanse args from addStatistics

### DIFF
--- a/R/auxiliary_giotto.R
+++ b/R/auxiliary_giotto.R
@@ -589,6 +589,11 @@ addCellStatistics <- function(gobject,
 #' @param detection_threshold detection threshold to consider a feature detected
 #' @param return_gobject boolean: return giotto object (default = TRUE)
 #' @param verbose be verbose
+#' @param \dots additional params passed to [expanse()] when `stats` includes
+#'   `"area"`. Most useful is `engine`: on a disk-backed polygon store,
+#'   `engine = "sedona"` computes areas with a single `ST_Area` query instead
+#'   of tiling, which avoids a large fan-out cost when a parallel `future`
+#'   plan is set.
 #' @returns giotto object if return_gobject = TRUE, else a list with results
 #' @details
 #' # `stats` options
@@ -608,7 +613,8 @@ addStatistics <- function(gobject,
     expression_values = c("normalized", "scaled", "custom"),
     detection_threshold = 0,
     return_gobject = TRUE,
-    verbose = TRUE) {
+    verbose = TRUE,
+    ...) {
     # Set feat_type and spat_unit
     spat_unit <- set_default_spat_unit(
         gobject = gobject,
@@ -675,7 +681,8 @@ addStatistics <- function(gobject,
         poly_stats <- .add_poly_statistics(gobject,
             spat_unit = spat_unit,
             stats = stats,
-            return_gobject = return_gobject
+            return_gobject = return_gobject,
+            ...
         )
         if (isTRUE(return_gobject)) {
             gobject <- poly_stats
@@ -786,7 +793,8 @@ addFeatsPerc <- function(gobject,
 .add_poly_statistics <- function(gobject,
     spat_unit = "cell",
     stats = c("area"),
-    return_gobject = TRUE
+    return_gobject = TRUE,
+    ...
 ) {
     stat_choices <- c("area")
     stats <- match.arg(
@@ -802,7 +810,7 @@ addFeatsPerc <- function(gobject,
         else return(data.table::data.table(cell_ID = spatIDs(gobject)))
     }
     res_dt <- if ("area" %in% stats) {
-        expanse(gpoly, output = "data.table")
+        expanse(gpoly, output = "data.table", ...)
     } else {
         data.table::data.table(cell_ID = spatIDs(gobject))
     }

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -492,7 +492,18 @@ setMethod("clusterData", signature("nnNetObj", "NNClusParam"), function(x, param
     seed_number = 1234,
     output = c("data.table", "factor"),
     ...) {
-    clusterData(x[], 
+    net <- x[]
+
+    # A disk-backed network holds a store, not an igraph. Materialize a
+    # minimal igraph for the partition -- the graph is only n x k edges, so
+    # it fits even when the expression matrix does not.
+    if (inherits(net, "dataStore")) {
+        package_check("GiottoDisk",
+            repository = "github:giotto-suite/GiottoDisk")
+        net <- GiottoDisk::storeRead(net, output = "igraph", minimal = TRUE)
+    }
+
+    clusterData(net,
         param = param,
         set_seed = set_seed,
         seed_number = seed_number,

--- a/man/addStatistics.Rd
+++ b/man/addStatistics.Rd
@@ -12,7 +12,8 @@ addStatistics(
   expression_values = c("normalized", "scaled", "custom"),
   detection_threshold = 0,
   return_gobject = TRUE,
-  verbose = TRUE
+  verbose = TRUE,
+  ...
 )
 }
 \arguments{
@@ -32,6 +33,12 @@ default = c("cell", "feature") See details}
 \item{return_gobject}{boolean: return giotto object (default = TRUE)}
 
 \item{verbose}{be verbose}
+
+\item{\dots}{additional params passed to \code{\link[terra:expanse]{expanse()}} when \code{stats} includes
+\code{"area"}. Most useful is \code{engine}: on a disk-backed polygon store,
+\code{engine = "sedona"} computes areas with a single \code{ST_Area} query instead
+of tiling, which avoids a large fan-out cost when a parallel \code{future}
+plan is set.}
 }
 \value{
 giotto object if return_gobject = TRUE, else a list with results


### PR DESCRIPTION
clusterData(nnNetObj) handed the raw @network slot down, which is a parquetEdgeStore on a backed gobject and matched no method. Now materializes a minimal igraph first -- the graph is only n x k edges.

addStatistics gains `...`, forwarded to expanse() for the "area" stat. engine = "sedona" computes areas in one ST_Area query instead of tiling: 21.9s -> 1.5s under a 10-worker future plan, identical values.