### PR TITLE
Carry a local group-average helper until featStatsParam arrives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Giotto 4.2.4 (in development)
 
 ## Bug fixes
+* gini markers and ligand-receptor scoring now match cluster labels to expression columns by `cell_ID`. The expression matrix and cell metadata are fetched independently and are not guaranteed to share a cell order, so per-cluster means were computed over mislabelled cells. On `GiottoData::loadGiottoMini("visium")` none of the 624 cells were in matching position. **Results will change for affected objects**; they were wrong before.
 * gini `rank_score` now takes effect. It compared against a rescaled rank capped at 1, and `findMarkers_one_vs_all()` never forwarded it. Default `1` -> `Inf` keeps results unchanged.
 * gini `expression_rank` and `detection_rank` now hold ranks, not the `[1, 0.1]` weight behind `comb_score`. Row counts and `comb_score` unchanged.
 

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -1,3 +1,66 @@
+# TODO: remove both helpers below once analyzeData(x, featStatsParam) reaches
+# this branch from gsource. They are a temporary local copy: the grouped verb
+# computes both statistics in one pass -- `mean_expr` is the average and
+# `perc_cells / 100` the detection fraction -- and works on disk-backed
+# expression, which these do not.
+#
+# GiottoClass exported equivalents of these. `create_average_detection_DT()`
+# has since been removed there, and `create_average_DT()` is retained only for
+# an internal GiottoClass caller, so Giotto now carries its own.
+#
+# Group membership is keyed on `cell_ID`: `getExpression()` and
+# `getCellMetadata()` are fetched independently and the suite makes no
+# guarantee that they share a cell order.
+.average_by_group <- function(gobject, spat_unit, feat_type, meta_data_name,
+    expression_values, detection_threshold = NULL) {
+    expr_data <- getExpression(
+        gobject = gobject,
+        spat_unit = spat_unit,
+        feat_type = feat_type,
+        values = expression_values,
+        output = "matrix"
+    )
+    cell_metadata <- getCellMetadata(gobject,
+        spat_unit = spat_unit,
+        feat_type = feat_type,
+        output = "data.table",
+        copy_obj = TRUE
+    )
+    if (!meta_data_name %in% colnames(cell_metadata)) {
+        stop("metadata column '", meta_data_name, "' not found",
+            call. = FALSE
+        )
+    }
+
+    ord <- match(colnames(expr_data), cell_metadata[["cell_ID"]])
+    if (anyNA(ord)) {
+        stop(
+            "expression columns and cell metadata do not describe the same ",
+            "cells; cannot align them.",
+            call. = FALSE
+        )
+    }
+    grouping <- cell_metadata[[meta_data_name]][ord]
+
+    detection <- !is.null(detection_threshold)
+    savelist <- lapply(unique(cell_metadata[[meta_data_name]]), function(group) {
+        temp <- expr_data[, grouping == group, drop = FALSE]
+        if (detection) {
+            rowSums_flex(as.matrix(temp) > detection_threshold) / ncol(temp)
+        } else {
+            rowMeans_flex(temp)
+        }
+    })
+    names(savelist) <- paste0(
+        "cluster_", unique(cell_metadata[[meta_data_name]])
+    )
+
+    out <- do.call("cbind", savelist)
+    rownames(out) <- rownames(expr_data)
+    as.data.frame(out)
+}
+
+
 #' @title findScranMarkers
 #' @name findScranMarkers
 #' @description Identify marker genes for all or selected clusters based on
@@ -702,7 +765,7 @@ findGiniMarkers <- function(
 
 
     # average expression per cluster
-    aggr_sc_clusters <- create_average_DT(
+    aggr_sc_clusters <- .average_by_group(
         gobject = gobject,
         feat_type = feat_type,
         spat_unit = spat_unit,
@@ -723,7 +786,7 @@ findGiniMarkers <- function(
 
 
     ## detection per cluster
-    aggr_detection_sc_clusters <- create_average_detection_DT(
+    aggr_detection_sc_clusters <- .average_by_group(
         gobject = gobject,
         spat_unit = spat_unit,
         feat_type = feat_type,

--- a/R/spatial_interaction.R
+++ b/R/spatial_interaction.R
@@ -2092,11 +2092,14 @@ print.combIcfObject <- function(x, ...) {
         feat_type = feat_type
     )
 
-    average_DT <- create_average_DT(
+    # TODO: replace with analyzeData(x, featStatsParam) once that reaches this
+    # branch from gsource. See .average_by_group() in differential_expression.R
+    average_DT <- .average_by_group(
         gobject = gobject,
         feat_type = feat_type,
         spat_unit = spat_unit,
-        meta_data_name = cluster_column
+        meta_data_name = cluster_column,
+        expression_values = "normalized"
     )
 
     # change column names back to original

--- a/tests/testthat/test_04_average_by_group.R
+++ b/tests/testthat/test_04_average_by_group.R
@@ -1,0 +1,63 @@
+
+# .average_by_group() is a temporary local copy of the GiottoClass helpers,
+# carried until analyzeData(x, featStatsParam) reaches this branch. These
+# tests pin the property that made the originals wrong: group membership must
+# be keyed on cell_ID, not on position.
+
+g <- test_data$vis
+EX <- getExpression(g, values = "normalized", output = "matrix")
+MD <- getCellMetadata(g, output = "data.table")
+CLUS <- "leiden_clus"
+
+.ref_by_id <- function(fun) {
+    lv <- unique(MD[[CLUS]])
+    out <- vapply(lv, function(k) {
+        ids <- MD[get(CLUS) == k][["cell_ID"]]
+        fun(EX[, colnames(EX) %in% ids, drop = FALSE])
+    }, numeric(nrow(EX)))
+    colnames(out) <- paste0("cluster_", lv)
+    out
+}
+
+test_that("group means select cells by identifier, not position", {
+    got <- as.matrix(Giotto:::.average_by_group(
+        g, NULL, NULL, CLUS, "normalized"
+    ))
+    expect_equal(got, .ref_by_id(Matrix::rowMeans), ignore_attr = TRUE)
+})
+
+test_that("detection fractions select cells by identifier", {
+    got <- as.matrix(Giotto:::.average_by_group(
+        g, NULL, NULL, CLUS, "normalized",
+        detection_threshold = 0
+    ))
+    ref <- .ref_by_id(function(m) Matrix::rowSums(m > 0) / ncol(m))
+    expect_equal(got, ref, ignore_attr = TRUE)
+})
+
+test_that("results are invariant to cell metadata row order", {
+    # holds regardless of any fixture's incidental ordering
+    cm <- getCellMetadata(g, output = "cellMetaObj")
+    set.seed(9)
+    cm[] <- cm[][sample(nrow(cm[]))]
+    g2 <- setGiotto(g, cm, verbose = FALSE)
+
+    a <- Giotto:::.average_by_group(g, NULL, NULL, CLUS, "normalized")
+    b <- Giotto:::.average_by_group(g2, NULL, NULL, CLUS, "normalized")
+    expect_equal(a[, sort(colnames(a))], b[, sort(colnames(b))])
+})
+
+test_that("the column contract downstream code relies on is preserved", {
+    got <- Giotto:::.average_by_group(g, NULL, NULL, CLUS, "normalized")
+    expect_true(all(grepl("^cluster_", colnames(got))))
+    expect_equal(rownames(got), rownames(EX))
+    # column order follows first appearance in the metadata, as before
+    expect_equal(colnames(got), paste0("cluster_", unique(MD[[CLUS]])))
+})
+
+test_that("a missing metadata column errors", {
+    expect_error(
+        Giotto:::.average_by_group(g, NULL, NULL, "not_a_column", "normalized"),
+        "not found"
+    )
+})


### PR DESCRIPTION
GiottoClass removed `create_average_detection_DT()`
(giotto-suite/GiottoClass#387), which `findGiniMarkers()` on this branch calls.
Giotto no longer builds against GiottoClass@dev.

Both aggregates now come from a local `.average_by_group()`, flagged `TODO` for
removal once `analyzeData(x, featStatsParam)` reaches this branch from
`gsource`. The grouped verb computes both statistics in one pass — `mean_expr`
is the average, `perc_cells / 100` the detection fraction — and works on
disk-backed expression, which this copy does not. It is deliberately temporary.

`spatial_interaction.R`'s ligand-receptor aggregate moves to the same helper,
which decouples Giotto from the remaining GiottoClass export entirely.

## Not a straight copy

The local version carries the alignment fix from
giotto-suite/GiottoClass#385 rather than the original behaviour. Group
membership is keyed on `cell_ID`, because `getExpression()` and
`getCellMetadata()` are fetched independently and nothing guarantees they share
a cell order — on `loadGiottoMini("visium")` **none of the 624 cells are in
matching position**, so per-cluster means were being taken over mislabelled
cells. **Results will change for affected objects**; they were wrong before.

The column contract is unchanged — `cluster_` prefixes, feature rownames,
metadata-appearance column order — so callers are untouched.

## Tests

Seven new tests assert both statistics against an id-keyed reference, that
results are invariant to permuting metadata rows, and that the column contract
holds. Existing gini suite (55) passes.

## Still outstanding on this branch

`findScranMarkers()` has the same positional defect independently — it passes
`cell_metadata[[cluster_column]]` straight to `scran::findMarkers()`. It is
worse there: 522 of 624 labels wrong, top-10 markers overlapping the correct
result by 1%. The verb-level fix does not reach this branch, because
`featStatsParam` and `scranMarkersParam` only exist on `gsource`. Not addressed
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)