### PR TITLE
Merge suite_dev into gsource: scran alignment via the verb

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Giotto 4.2.4 (in development)
 
 ## Bug fixes
+* `findScranMarkers()` now matches cluster labels to expression columns by `cell_ID` before handing them to `scran::findMarkers()`, which pairs them positionally. On `GiottoData::loadGiottoMini("visium")` only 1 of 70 top-10 markers agreed with the correctly labelled run. `findScranMarkers_one_vs_all()` delegates and is fixed with it. **Results will change for affected objects**; they were wrong before.
 * gini markers and ligand-receptor scoring now match cluster labels to expression columns by `cell_ID`. The expression matrix and cell metadata are fetched independently and are not guaranteed to share a cell order, so per-cluster means were computed over mislabelled cells. On `GiottoData::loadGiottoMini("visium")` none of the 624 cells were in matching position. **Results will change for affected objects**; they were wrong before.
 * gini `rank_score` now takes effect. It compared against a rescaled rank capped at 1, and `findMarkers_one_vs_all()` never forwarded it. Default `1` -> `Inf` keeps results unchanged.
 * gini `expression_rank` and `detection_rank` now hold ranks, not the `[1, 0.1]` weight behind `comb_score`. Row counts and `comb_score` unchanged.

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -210,8 +210,25 @@ findScranMarkers <- function(
 
 
     ## SCRAN ##
+    # TODO: remove this reorder once analyzeData(x, scranMarkersParam) reaches
+    # this branch from gsource. There `.markers_scran()` resolves `groups` by
+    # `cell_ID` for every backend, so the alignment stops being this function's
+    # problem.
+    #
+    # `scran::findMarkers()` takes `groups` positionally, and nothing so far has
+    # put the two sides in the same order: `getExpression()` and
+    # `getCellMetadata()` are fetched independently, and the subset branches
+    # above filter `cell_metadata` into metadata order while
+    # `colnames(expr_data) %in% ...` keeps the matrix in its own.
+    ord <- match(colnames(expr_data), cell_metadata[["cell_ID"]])
+    if (anyNA(ord)) {
+        stop("expression columns and cell metadata do not describe the same ",
+            "cells; cannot align them.",
+            call. = FALSE
+        )
+    }
     marker_results <- scran::findMarkers(
-        x = expr_data, groups = cell_metadata[[cluster_column]], ...
+        x = expr_data, groups = cell_metadata[[cluster_column]][ord], ...
     )
 
     # data.table variables

--- a/tests/testthat/test_04_markers_scran_alignment.R
+++ b/tests/testthat/test_04_markers_scran_alignment.R
@@ -1,0 +1,83 @@
+# findScranMarkers() hands `expr_data` and a groups vector to
+# `scran::findMarkers()`, which pairs them positionally. Expression and cell
+# metadata are fetched independently and are not guaranteed to share a cell
+# order, so the labels have to be reordered onto the matrix first.
+#
+# TODO: these lock the temporary reorder in findScranMarkers(). Once
+# analyzeData(x, scranMarkersParam) arrives from gsource the resolution moves
+# into `.markers_scran()`, and these should be retargeted there rather than
+# deleted -- the behaviour they assert stays required.
+
+g <- test_data$vis
+
+test_that("mini visium really does disagree on cell order", {
+    # The premise of the rest of the file. If this ever fails, the fixture
+    # changed and these tests stop covering anything.
+    EX <- getExpression(g, values = "normalized", output = "matrix")
+    ids <- getCellMetadata(g, output = "data.table")[["cell_ID"]]
+    expect_setequal(colnames(EX), ids)
+    expect_false(identical(colnames(EX), ids))
+    expect_equal(sum(colnames(EX) == ids), 0L)
+})
+
+test_that("findScranMarkers labels cells by cell_ID, not by position", {
+    skip_if_not_installed("scran")
+
+    # returns an unnamed list of data.tables, one per cluster, each tagged with
+    # a `cluster` column
+    got <- data.table::rbindlist(findScranMarkers(g,
+        cluster_column = "leiden_clus", expression_values = "normalized"
+    ))
+
+    # Independent ground truth: call scran directly, with the grouping put into
+    # the matrix's column order by name.
+    EX <- getExpression(g, values = "normalized", output = "matrix")
+    cm <- getCellMetadata(g, output = "data.table")
+    grp <- cm[["leiden_clus"]][match(colnames(EX), cm[["cell_ID"]])]
+    ref <- scran::findMarkers(x = EX, groups = grp)
+
+    expect_setequal(unique(got$cluster), names(ref))
+    for (k in names(ref)) {
+        a <- got[cluster == k]
+        b <- data.table::as.data.table(ref[[k]])
+        b[, feats := rownames(ref[[k]])]
+        # same features in the same order, and the same statistics on them
+        expect_equal(a$feats, b$feats, info = k)
+        expect_equal(a$p.value, b$p.value, info = k)
+        expect_equal(a$FDR, b$FDR, info = k)
+    }
+})
+
+test_that("the misaligned grouping would have given different markers", {
+    skip_if_not_installed("scran")
+
+    # Not a tautology check: it establishes that the reorder changes the answer
+    # on this object, so the test above is measuring something.
+    EX <- getExpression(g, values = "normalized", output = "matrix")
+    cm <- getCellMetadata(g, output = "data.table")
+    ord <- match(colnames(EX), cm[["cell_ID"]])
+
+    aligned <- scran::findMarkers(x = EX, groups = cm[["leiden_clus"]][ord])
+    naive <- scran::findMarkers(x = EX, groups = cm[["leiden_clus"]])
+
+    top10 <- function(res, k) head(rownames(res[[k]]), 10L)
+    overlap <- vapply(names(aligned), function(k) {
+        length(intersect(top10(aligned, k), top10(naive, k)))
+    }, integer(1L))
+
+    # Top-10 markers per cluster barely overlap between the two groupings.
+    expect_lt(sum(overlap), 10L)
+})
+
+test_that("findScranMarkers_one_vs_all inherits the alignment", {
+    skip_if_not_installed("scran")
+
+    # It delegates to findScranMarkers() per cluster, so it needs no reorder of
+    # its own -- this asserts that delegation still holds.
+    res <- findScranMarkers_one_vs_all(g,
+        cluster_column = "leiden_clus", expression_values = "normalized",
+        verbose = FALSE
+    )
+    expect_true(nrow(res) > 0L)
+    expect_true(all(c("feats", "cluster") %in% names(res)))
+})


### PR DESCRIPTION
Threads #1279 through to `gsource`.

**The diff is NEWS + tests only, by design.** The reorder #1279 added never
existed on `gsource`, so there is nothing to delete here. Those are the same lines
rewritten two ways: `suite_dev` reorders labels for a direct
`scran::findMarkers()` call, while `gsource` replaced that call with
`analyzeData(x, markersParam(method = "scran"))`. Git raised it as a conflict for
that reason, and it resolves to the `gsource` side — so the block never arrives
rather than arriving and being removed.

## What resolves how

**`findScranMarkers()`** keeps the verb call. `groups` is named by `cell_ID` and
`.markers_scran()` resolves it through `.align_groups()` for every backend, which
is what #1279's reorder was a stand-in for. The whole of #1279's change to
`R/differential_expression.R` was that reorder plus the one-line call edit, so
nothing else was dropped with it; its other two files came through.

**The tests carry over unchanged**, which is the substance of this PR. They assert
the public behaviour of `findScranMarkers()` without naming a mechanism, so
passing here is evidence the verb path genuinely delivers what the reorder did on
`suite_dev` — not merely that the block is absent. Only their header comment
changed, to stop describing a reorder that does not exist on this branch.

**NEWS** — the `suite_dev` bullet described the reorder, so its measurement (1 of
70 top-10 scran markers agreeing with the correctly labelled run) was folded into
the existing `cell_ID` alignment bullet, and `findScranMarkers()` added to the
functions it names. That bullet listed only `findScranMarkers_one_vs_all()`, which
understated the scope: plain `findScranMarkers()` was fixed here too by the
earlier verb rewire.

## Verification

134 assertions across the four marker/statistics files, all passing:

| file | assertions |
|---|---|
| `test_04_markers_scran_alignment.R` | 28 |
| `test_04_markers_gini.R` | 55 |
| `test_04_feat_stats_grouped.R` | 25 |
| `test-markers-dispatch.R` | 26 |

After this, `gsource` has no temporary alignment stand-ins: #1277's
`.average_by_group()` was dropped at the previous merge, and #1279's reorder never
lands. Both are superseded by the verb.