### PR TITLE
Stop passing image_type to getGiottoImage

### DIFF
--- a/R/image_registration.R
+++ b/R/image_registration.R
@@ -163,8 +163,7 @@
         img_type = img_type
     )))) {
         giottoImage_list <- lapply(
-            X = gobject_list, FUN = getGiottoImage, name = image_unreg,
-            image_type = img_type
+            X = gobject_list, FUN = getGiottoImage, name = image_unreg
         )
         image_corners <- lapply(giottoImage_list, .get_img_corners)
 

--- a/tests/testthat/test_98_visium.R
+++ b/tests/testthat/test_98_visium.R
@@ -77,7 +77,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_nofil)), 4992L)
         # image
-        i_nofil <- getGiottoImage(g_nofil, image_type = "largeImage")
+        i_nofil <- getGiottoImage(g_nofil)
         expect_s4_class(i_nofil, "giottoLargeImage")
         expect_identical(dim(i_nofil), c(2000, 2000, 3))
         expect_equal(ext_to_rounded_num(i_nofil), c(0, 1e4, -1e4, 0))
@@ -107,7 +107,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_fil)), 1185L)
         # image
-        i_fil <- getGiottoImage(g_fil, image_type = "largeImage")
+        i_fil <- getGiottoImage(g_fil)
         expect_s4_class(i_fil, "giottoLargeImage")
         expect_identical(dim(i_fil), c(2000, 2000, 3))
         expect_equal(ext_to_rounded_num(i_fil), c(0, 1e4, -1e4, 0))
@@ -146,7 +146,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_nofil)), 4992L)
         # image
-        i_nofil <- getGiottoImage(g_nofil, image_type = "largeImage")
+        i_nofil <- getGiottoImage(g_nofil)
         expect_s4_class(i_nofil, "giottoLargeImage")
         expect_identical(dim(i_nofil), c(600, 600, 3))
         expect_equal(ext_to_rounded_num(i_nofil), c(0, 1e4, -1e4, 0))
@@ -185,7 +185,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_fil)), 1185L)
         # image
-        i_fil <- getGiottoImage(g_fil, image_type = "largeImage")
+        i_fil <- getGiottoImage(g_fil)
         expect_s4_class(i_fil, "giottoLargeImage")
         expect_identical(dim(i_fil), c(600, 600, 3))
         expect_equal(ext_to_rounded_num(i_fil), c(0, 1e4, -1e4, 0))


### PR DESCRIPTION
`getGiottoImage()`'s `image_type` formal is removed in giotto-suite/GiottoClass#381. It had been documented deprecated for a long time and was never read — the method body ignored it entirely.

Five call sites here would fail with `unused argument (image_type = ...)` once that lands:

- `R/image_registration.R:167`, in `.reg_img_minmax_finder()`
- `tests/testthat/test_98_visium.R` ×4

`img_type` stays live in `.reg_img_minmax_finder()` — `list_images_names(img_type =)` is a working filter and is unaffected by that PR.

## Ordering

**Merge this before GiottoClass#381.** It is also safe against current GiottoClass: the parameter is ignored there, and `name = NULL` already resolves to the first image, which is what the tests assert. So there is no window in which either side is broken, and this can land at any time.

## Test plan

- [ ] `test_98_visium.R` is gated on `skip_if_offline()` and downloads a Visium dataset into `tempdir()`; not run locally. Each changed line is immediately followed by `expect_s4_class(i, "giottoLargeImage")` plus exact `dim()` and `ext()` assertions, so a wrong image would fail loudly rather than pass silently.