### PR TITLE
Use canonical accessor argument names

### DIFF
--- a/R/interactivity.R
+++ b/R/interactivity.R
@@ -192,7 +192,7 @@ getCellsFromPolygon <- function(
     ## get polygons spatial info
     polygon_spatVector <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = polygon_name,
+        name = polygon_name,
         return_giottoPolygon = FALSE
     )
 
@@ -589,7 +589,7 @@ plotPolygons <- function(
     ## get polygons spatial info
     polygon_spatVector <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = polygon_name,
+        name = polygon_name,
         return_giottoPolygon = FALSE
     )
 

--- a/R/wnn.R
+++ b/R/wnn.R
@@ -388,7 +388,7 @@ runWNN <- function(
 
     gobject <- setMultiomics(
         gobject = gobject,
-        result = theta_weighted,
+        x = theta_weighted,
         spat_unit = spat_unit,
         feat_type = integrated_feat_type,
         integration_method = "WNN",
@@ -406,7 +406,7 @@ runWNN <- function(
 
         gobject <- setMultiomics(
             gobject = gobject,
-            result = w_list[feat_type],
+            x = w_list[feat_type],
             spat_unit = spat_unit,
             feat_type = integrated_feat_type,
             integration_method = "WNN",
@@ -525,7 +525,7 @@ runIntegratedUMAP <- function(
         ## store nn_network id
         gobject <- setMultiomics(
             gobject = gobject,
-            result = nn_network$id,
+            x = nn_network$id,
             spat_unit = spat_unit,
             feat_type = integrated_feat_type,
             integration_method = "WNN",
@@ -536,7 +536,7 @@ runIntegratedUMAP <- function(
         ## store nn_network dist
         gobject <- setMultiomics(
             gobject = gobject,
-            result = nn_network$dist,
+            x = nn_network$dist,
             spat_unit = spat_unit,
             feat_type = integrated_feat_type,
             integration_method = "WNN",


### PR DESCRIPTION
> **Draft — blocked on giotto-suite/GiottoClass#381.** CI will fail until that merges. See Ordering.

giotto-suite/GiottoClass#381 aligns the accessor generics on one shared formal contract, renaming the three that deviated. Two of them are used here:

| Generic | Was | Now |
|---|---|---|
| `setMultiomics` | `result` | `x` |
| `getPolygonInfo` | `polygon_name` | `name` |

Both old names keep working through deprecation aliases, so this changes no behaviour — it stops our own code from emitting our own deprecation warnings.

6 call sites:

- `R/wnn.R` ×4 — `setMultiomics(result=)` in `runWNN()` and `runIntegratedUMAP()`
- `R/interactivity.R` ×2 — `getPolygonInfo(polygon_name=)` in `getCellsFromPolygon()` and `plotPolygons()`

Only the argument names change. The right-hand sides are the enclosing functions' own parameters and are untouched, so the public signatures of these functions are unaffected.

## Ordering

**Merge after GiottoClass#381.** The canonical names do not merely warn before it — they error. `getPolygonInfo` has no `...` to absorb `name=` (`unused argument`), and `setMultiomics` leaves its required `result=` missing (`argument "result" is missing, with no default`). Verified against an installed GiottoClass.

Note this is the opposite ordering from #1283, which must merge *before* #381 — which is why the two are separate PRs rather than one.

## Test plan

- [x] `parse()` clean on both modified files
- [ ] Not runnable until #381 lands and GiottoClass is reinstalled; the suite currently fails on exactly the errors above. Worth actually running at that point rather than assuming — it is 6 lines, but currently unexercised.