### PR TITLE
Merge suite_dev into gsource

### DIFF
--- a/R/image_registration.R
+++ b/R/image_registration.R
@@ -163,8 +163,7 @@
         img_type = img_type
     )))) {
         giottoImage_list <- lapply(
-            X = gobject_list, FUN = getGiottoImage, name = image_unreg,
-            image_type = img_type
+            X = gobject_list, FUN = getGiottoImage, name = image_unreg
         )
         image_corners <- lapply(giottoImage_list, .get_img_corners)
 

--- a/R/interactivity.R
+++ b/R/interactivity.R
@@ -192,7 +192,7 @@ getCellsFromPolygon <- function(
     ## get polygons spatial info
     polygon_spatVector <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = polygon_name,
+        name = polygon_name,
         return_giottoPolygon = FALSE
     )
 
@@ -589,7 +589,7 @@ plotPolygons <- function(
     ## get polygons spatial info
     polygon_spatVector <- getPolygonInfo(
         gobject = gobject,
-        polygon_name = polygon_name,
+        name = polygon_name,
         return_giottoPolygon = FALSE
     )
 

--- a/R/wnn.R
+++ b/R/wnn.R
@@ -388,7 +388,7 @@ runWNN <- function(
 
     gobject <- setMultiomics(
         gobject = gobject,
-        result = theta_weighted,
+        x = theta_weighted,
         spat_unit = spat_unit,
         feat_type = integrated_feat_type,
         integration_method = "WNN",
@@ -406,7 +406,7 @@ runWNN <- function(
 
         gobject <- setMultiomics(
             gobject = gobject,
-            result = w_list[feat_type],
+            x = w_list[feat_type],
             spat_unit = spat_unit,
             feat_type = integrated_feat_type,
             integration_method = "WNN",
@@ -525,7 +525,7 @@ runIntegratedUMAP <- function(
         ## store nn_network id
         gobject <- setMultiomics(
             gobject = gobject,
-            result = nn_network$id,
+            x = nn_network$id,
             spat_unit = spat_unit,
             feat_type = integrated_feat_type,
             integration_method = "WNN",
@@ -536,7 +536,7 @@ runIntegratedUMAP <- function(
         ## store nn_network dist
         gobject <- setMultiomics(
             gobject = gobject,
-            result = nn_network$dist,
+            x = nn_network$dist,
             spat_unit = spat_unit,
             feat_type = integrated_feat_type,
             integration_method = "WNN",

--- a/tests/testthat/test_98_visium.R
+++ b/tests/testthat/test_98_visium.R
@@ -77,7 +77,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_nofil)), 4992L)
         # image
-        i_nofil <- getGiottoImage(g_nofil, image_type = "largeImage")
+        i_nofil <- getGiottoImage(g_nofil)
         expect_s4_class(i_nofil, "giottoLargeImage")
         expect_identical(dim(i_nofil), c(2000, 2000, 3))
         expect_equal(ext_to_rounded_num(i_nofil), c(0, 1e4, -1e4, 0))
@@ -107,7 +107,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_fil)), 1185L)
         # image
-        i_fil <- getGiottoImage(g_fil, image_type = "largeImage")
+        i_fil <- getGiottoImage(g_fil)
         expect_s4_class(i_fil, "giottoLargeImage")
         expect_identical(dim(i_fil), c(2000, 2000, 3))
         expect_equal(ext_to_rounded_num(i_fil), c(0, 1e4, -1e4, 0))
@@ -146,7 +146,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_nofil)), 4992L)
         # image
-        i_nofil <- getGiottoImage(g_nofil, image_type = "largeImage")
+        i_nofil <- getGiottoImage(g_nofil)
         expect_s4_class(i_nofil, "giottoLargeImage")
         expect_identical(dim(i_nofil), c(600, 600, 3))
         expect_equal(ext_to_rounded_num(i_nofil), c(0, 1e4, -1e4, 0))
@@ -185,7 +185,7 @@ describe("Integrative testing with visium dataset", {
         # spatlocs
         expect_equal(nrow(getSpatialLocations(g_fil)), 1185L)
         # image
-        i_fil <- getGiottoImage(g_fil, image_type = "largeImage")
+        i_fil <- getGiottoImage(g_fil)
         expect_s4_class(i_fil, "giottoLargeImage")
         expect_identical(dim(i_fil), c(600, 600, 3))
         expect_equal(ext_to_rounded_num(i_fil), c(0, 1e4, -1e4, 0))


### PR DESCRIPTION
Brings the accessor-contract work (#1283, #1284) onto the gsource line. Clean merge, no conflicts.

- `R/image_registration.R` — drops `image_type` from the `getGiottoImage()` call in `.reg_img_minmax_finder()`
- `tests/testthat/test_98_visium.R` ×4 — same
- `R/wnn.R` ×4 — `setMultiomics(result=)` → `x=`
- `R/interactivity.R` ×2 — `getPolygonInfo(polygon_name=)` → `name=`

The remaining `polygon_name = polygon_name` in `interactivity.R` is a call to `getCellsFromPolygon()`, which has its own `polygon_name` parameter. Correctly untouched.

## Ordering

**Merge this before giotto-suite/GiottoClass's dev→gsource merge.** Right now `Giotto/gsource` still passes `image_type` and `GiottoClass/gsource` still accepts it — they lag together, so nothing is broken. If GiottoClass/gsource takes #381 first, that call breaks. Same before-then-after rule as the original rollout, replayed one line down.