### PR TITLE
test: set giotto.use_conda = FALSE in test setup

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,7 @@
 # Global options for testing
+options("giotto.use_conda" = FALSE)
 options("lifecycle_verbosity" = "quiet")
+options("giotto.no_python_warn" = TRUE)
 
 # Test Data Setup
 # ---------------


### PR DESCRIPTION
`tests/testthat/setup.R` did not disable conda, so on a machine without a conda
binary `loadGiottoMini()` errors during setup. Because that happens in `setup.R`
rather than in a test, it aborts **every** test file instead of skipping the
python-dependent ones — the suite cannot run at all.

Adds the two options GiottoClass's own `setup.R` already sets.

### Before / after

Running the full suite locally with no conda installed:

| | files that ran | result |
|---|---|---|
| before | 0 | `setup.R` aborts: `Unable to find a conda binary` |
| after | all | 0 failures, 265 passing, 2 errors |

The two remaining errors are environmental, not regressions: a missing python
`leidenalg` module in `test_03_clustering.R`, and a `cannot add bindings to a
locked environment` in `test-pca-recommend.R` that only appears when the runner
injects the package namespace as the parent env — that file passes 26/26 with a
plain env.

`suite` does not have these options either, so it likely wants the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)