### PR TITLE
fix: treat the Xenium panel json as optional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Giotto 4.2.4 (in development)
 
+## Bug fixes
+* `createGiottoXeniumObject()` no longer errors on Xenium-format directories that ship no panel json; feature metadata is generated from the expression matrix when the panel is absent.
+
 ## Breaking changes
 * `findScranMarkers_one_vs_all()` returns `cluster` as **character**. All `findMarkers_one_vs_all()` methods now agree on the type, so their results can be joined or stacked on `cluster` regardless of `method`; previously scran disagreed with gini. Code comparing against a numeric literal needs `"3"` rather than `3`. Note that `method = "mast"` labels the comparison (`"3_vs_others"`) rather than the bare cluster id, so joins across mast and the others still need a translation step.
 * `calculateHVF(method = "var_p_resid")` now computes analytic Pearson residuals itself, from **raw counts**, instead of taking the plain variance of whatever matrix it was handed. **Selected features will differ from previous releases.** Previously the residual criterion required running `normalizeGiotto(norm_methods = "pearson_resid")` first *and* passing `expression_values = "scaled"` (the slot that normalization writes to, not the `"normalized"` default) — a three-way agreement nothing verified, and which silently returned the variance of library-normalized values whenever it was not met. `expression_values` is now ignored for this method, with a warning if it was set explicitly. `normalizeGiotto(norm_methods = "pearson_resid")` is unaffected and remains available for producing residuals as a stored matrix.

--- a/R/convenience_xenium.R
+++ b/R/convenience_xenium.R
@@ -466,14 +466,24 @@ setMethod(
 
 
             # feat metadata
-            fx <- funs$load_featmeta(
-                path = gene_panel_json_path,
-                # ID = symbols makes sense with the subcellular feat_IDs
-                gene_ids = "symbols",
-                # no dropcols
-                verbose = verbose
-            )
-            g <- setGiotto(g, fx, verbose = FALSE)
+            # `gene_panel_json_path` is optional, and some Xenium-format
+            # exports ship no panel json. Feature metadata is generated from
+            # the expression matrix when it is absent, so skip rather than
+            # error -- matching how the other optional inputs are handled.
+            if (length(gene_panel_json_path) > 0L &&
+                nzchar(gene_panel_json_path[[1L]])) {
+                fx <- funs$load_featmeta(
+                    path = gene_panel_json_path,
+                    # ID = symbols makes sense with the subcellular feat_IDs
+                    gene_ids = "symbols",
+                    # no dropcols
+                    verbose = verbose
+                )
+                g <- setGiotto(g, fx, verbose = FALSE)
+            } else {
+                vmsg("No panel metadata file found, skipping feature metadata",
+                    .v = verbose)
+            }
 
 
             # cell metadata


### PR DESCRIPTION
`gene_panel_json_path` is documented `# optional` in `createGiottoXeniumObject()`'s
signature, but the panel was loaded unconditionally. Every other optional input is
guarded — `if (load_transcripts)`, `if (load_expression)`, `if (load_cellmeta)` — and
the panel load sat between two of those with no guard of its own.

The result on a directory with no panel file:

```
Error in .xenium_featmeta(): Assertion on 'path' failed: No file provided.
```

It fails **after** the whole expression matrix has been written, so the work is lost
and a half-built project directory is left behind.

Nothing is gained by aborting. Giotto builds feature metadata from the matrix when no
panel is supplied — verified below.

### What the panel actually contributes

`ensembl` and `type` columns. Gene symbols come from the matrix either way, and no
part of filtering, normalization, PCA or clustering reads the panel. The one genuine
loss is `gene_ids = "ensembl"`, which cannot work without it.

### Companion PR

**Requires giotto-suite/GiottoDisk#49 to cover the on-disk path.** Both packages carry
their own copy of the Xenium `create_gobject` orchestration, so this change alone
leaves `createGiottoXeniumObject(backend = )` still failing. Fixing Giotto first and
re-testing is how the second copy was found.

### Verification

Real dataset with no panel (Atera whole-transcriptome, 18,028 genes x 170,057 cells;
its `experiment.xenium` reports `panel_design_id: N/A` for a pre-release panel, so no
panel file exists by design rather than by omission):

| | before | after |
|---|---|---|
| in-memory | error | loads, feature metadata 18,028 rows |
| `backend =` | error | loads, 18,028 rows (with the GiottoDisk PR) |

Regression on a panel-bearing dataset (`workshop_xenium`): feature metadata still
`feat_ID, ensembl, type` for 397 features, so the guard only skips when there is
nothing to read.

Suite: 0 failures, 257 passing, 2 pre-existing environmental errors (missing python
`leidenalg`; a locked-environment error in `test-pca-recommend.R` that appears only
when the runner injects the package namespace as parent env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
