### PR TITLE
feat: fall back to cell-metadata centroids for spatial locations

### DIFF
--- a/R/convenience_xenium.R
+++ b/R/convenience_xenium.R
@@ -254,6 +254,17 @@ setMethod(
         }
         obj@calls$load_cellmeta <- cmeta_fun
 
+        # load spatlocs (cell centroids, used when there are no polygons)
+        sloc_fun <- function(
+        path = cell_meta_path,
+        flip_vertical = TRUE,
+        cores = determine_cores(),
+        verbose = NULL) {
+            .xenium_spatlocs(path = path, flip_vertical = flip_vertical,
+                cores = cores, verbose = verbose)
+        }
+        obj@calls$load_spatlocs <- sloc_fun
+
         # load featmeta
         fmeta_fun <- function(
         path = panel_meta_path,
@@ -594,13 +605,21 @@ setMethod(
             }
 
             # centroids
-            vmsg(.v = verbose, "calculating centroids")
+            # polygon centroids are preferred. With no polygons loaded there
+            # are none to derive, so fall back to the centroids recorded in
+            # the cell metadata file.
             spat_units_to_calc <- list_spatial_info_names(g)
-            g <- addSpatialCentroidLocations(g,
-                poly_info = spat_units_to_calc,
-                provenance = as.list(spat_units_to_calc),
-                verbose = FALSE
-            )
+            if (length(spat_units_to_calc) > 0L) {
+                vmsg(.v = verbose, "calculating centroids")
+                g <- addSpatialCentroidLocations(g,
+                    poly_info = spat_units_to_calc,
+                    provenance = as.list(spat_units_to_calc),
+                    verbose = FALSE
+                )
+            } else {
+                sl <- funs$load_spatlocs(verbose = verbose)
+                if (!is.null(sl)) g <- setGiotto(g, sl, verbose = FALSE)
+            }
 
             vmsg(.v = verbose, "done")
 
@@ -1143,6 +1162,52 @@ importXenium <- function(xenium_dir = NULL, qv_threshold = 20, backend = NULL) {
         dplyr::mutate(cell_id = cast(cell_id, arrow::string())) %>%
         dplyr::select(-dplyr::any_of(dropcols)) %>%
         data.table::as.data.table()
+}
+
+
+## spatlocs ####
+
+# Cell centroids as spatial locations.
+#
+# The cell metadata file carries `x_centroid` / `y_centroid`, which
+# `.xenium_cellmeta()` drops on purpose -- coordinates belong in spatial
+# locations, not metadata. This reads the same file for exactly those columns,
+# and is the fallback used when no polygons were loaded and there are therefore
+# no polygon centroids to derive.
+.xenium_spatlocs <- function(path, flip_vertical = TRUE,
+    cores = determine_cores(), verbose = NULL) {
+    if (missing(path) || length(path) == 0L || !nzchar(path[[1L]])) {
+        return(NULL)
+    }
+    checkmate::assert_file_exists(path)
+    cols <- c("cell_id", "x_centroid", "y_centroid")
+
+    e <- file_extension(path) %>%
+        head(1L) %>%
+        tolower()
+    vmsg("Loading cell centroids as spatial locations...", .v = verbose)
+    sl <- switch(e,
+        "csv" = data.table::fread(path, nThread = cores, select = cols),
+        "parquet" = arrow::read_parquet(file = path, as_data_frame = FALSE) %>%
+            dplyr::mutate(cell_id = cast(cell_id, arrow::string())) %>%
+            dplyr::select(dplyr::all_of(cols)) %>%
+            data.table::as.data.table()
+    )
+    data.table::setnames(sl, cols, c("cell_ID", "sdimx", "sdimy"))
+
+    # same convention as the transcript and polygon loaders, which both
+    # default to flip_vertical = TRUE. Without this the fallback would place
+    # cells mirrored against every other Xenium modality.
+    sdimy <- NULL # NSE var
+    if (flip_vertical) sl[, sdimy := -sdimy]
+
+    createSpatLocsObj(
+        coordinates = sl,
+        name = "raw",
+        spat_unit = "cell",
+        provenance = "cell",
+        verbose = FALSE
+    )
 }
 
 

--- a/tests/testthat/test-xenium-spatlocs.R
+++ b/tests/testthat/test-xenium-spatlocs.R
@@ -1,0 +1,61 @@
+# Cell centroids as a spatial-locations fallback, used when a Xenium export
+# ships no boundary files. The cell metadata file carries x_centroid/y_centroid
+# and .xenium_cellmeta() drops them on purpose, so this reads them separately.
+
+.mk_cells_parquet <- function(dir) {
+    dir.create(dir, showWarnings = FALSE, recursive = TRUE)
+    dt <- data.table::data.table(
+        cell_id = c("a", "b", "c"),
+        x_centroid = c(1.5, 2.5, 3.5),
+        y_centroid = c(10.0, 20.0, 30.0),
+        total_counts = c(5L, 6L, 7L)
+    )
+    p <- file.path(dir, "cells.parquet")
+    arrow::write_parquet(dt, p)
+    p
+}
+
+test_that("centroids become spatial locations", {
+    skip_if_not_installed("arrow")
+    d <- file.path(tempdir(), "xen_sl_1")
+    on.exit(unlink(d, recursive = TRUE), add = TRUE)
+    sl <- Giotto:::.xenium_spatlocs(.mk_cells_parquet(d), verbose = FALSE)
+
+    expect_s4_class(sl, "spatLocsObj")
+    dt <- sl[]
+    expect_setequal(colnames(dt), c("cell_ID", "sdimx", "sdimy"))
+    expect_setequal(dt$cell_ID, c("a", "b", "c"))
+    expect_equal(dt[cell_ID == "a"]$sdimx, 1.5)
+})
+
+test_that("y is flipped, matching the transcript and polygon loaders", {
+    skip_if_not_installed("arrow")
+    d <- file.path(tempdir(), "xen_sl_2")
+    on.exit(unlink(d, recursive = TRUE), add = TRUE)
+    p <- .mk_cells_parquet(d)
+
+    # both default to flip_vertical = TRUE, so spatial locations must agree --
+    # otherwise cells land mirrored against every other Xenium modality
+    expect_true(formals(Giotto:::.xenium_spatlocs)$flip_vertical)
+    flipped <- Giotto:::.xenium_spatlocs(p, verbose = FALSE)[]
+    expect_equal(flipped[cell_ID == "a"]$sdimy, -10)
+
+    unflipped <- Giotto:::.xenium_spatlocs(p, flip_vertical = FALSE,
+        verbose = FALSE)[]
+    expect_equal(unflipped[cell_ID == "a"]$sdimy, 10)
+})
+
+test_that("an absent cell metadata path yields NULL rather than an error", {
+    expect_null(Giotto:::.xenium_spatlocs(character(0)))
+    expect_null(Giotto:::.xenium_spatlocs(NULL))
+    expect_null(Giotto:::.xenium_spatlocs(""))
+})
+
+test_that("the create path falls back to centroids when no polygons load", {
+    # guards against the two create_gobject copies drifting: the fallback has
+    # to be wired in Giotto's copy as well as GiottoDisk's
+    src <- paste(deparse(
+        methods::getMethod("initialize", "XeniumReader")@.Data
+    ), collapse = " ")
+    expect_true(grepl("load_spatlocs", src))
+})


### PR DESCRIPTION
Spatial locations were only ever derived from polygon centroids, so a Xenium export
containing an aggregated matrix and a cell table but **no boundary files** produced an
object with no coordinates — nothing could be plotted or spatially analysed.

The coordinates were already being read and thrown away. The cellmeta closure defaults
to `dropcols = c("x_centroid", "y_centroid")`, on the correct reasoning that coordinates
belong in spatial locations rather than metadata. Nothing caught them on the way out.

### What this adds

- `.xenium_spatlocs()` — reads `cell_id` / `x_centroid` / `y_centroid` from the cell
  metadata file and returns a `spatLocsObj` via `createSpatLocsObj()`, the same helper
  the VisiumHD reader uses. Independent of `load_cellmeta`, since coordinates are not
  metadata.
- a `load_spatlocs` closure alongside the other per-modality reader closures.
- in `create_gobject`, the centroid block is guarded: polygon centroids when spatial
  info exists, this fallback otherwise. Pure addition — no existing path changes.

### The y convention

The fallback applies `flip_vertical = TRUE`, matching the transcript
(`tx[, y := -y]`) and polygon (`vertex_y := -vertex_y`) loaders. Without it the
fallback would place cells mirrored against every other Xenium modality. This was a real
bug during development, caught by comparing fallback coordinates against polygon-derived
ones rather than just checking they existed: max |dy| was 7,215 against max |dx| of 5.2.
There is now a test asserting both the default and the negation.

### Companion PR

**giotto-suite/GiottoDisk#50** wires the same fallback into GiottoDisk's copy of the
orchestration. Without it, `createGiottoXeniumObject(backend = )` still yields no
coordinates.

### Verification

Minimal export (matrix + cell table, no boundaries):

| dataset | in-memory | on-disk |
|---|---|---|
| Xenium lung (377 x 162,254) | 162,254 | 162,254, identical |
| Atera whole-transcriptome (18,028 x 170,057) | not run — 307M nonzeros | 170,057 |

On both datasets, with boundaries present, coordinates still come from polygon
centroids: they differ from the metadata centroids only by the centroid-definition
difference, and by a similar amount in x and y (lung 5.2 / 8.0; Atera 0.64 / 0.44), which
is what rules out a flip. `cell_ID` sets match the expression matrix exactly.

Suite: 0 failures, 268 passing, 2 pre-existing environmental errors (missing python
`leidenalg`; a locked-environment error in `test-pca-recommend.R` that appears only when
the runner injects the package namespace as parent env).

`man/` is not regenerated — the change adds no roxygen, but `.xenium_spatlocs()` is a new
internal, so a `document()` run with roxygen2 8.0.0 is still wanted (local install is
7.3.3 and would rewrite every page in the older format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)