### PR TITLE
Point URL at giottosuite.com and restore Wen Wang's ORCID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,14 +15,14 @@ Authors@R: c(
 	person("Edward", "Ruiz", email = "ecruiz@bu.edu",
 		 role = c("aut")),
 	person("Wen", "Wang", email = "wen.wang@mssm.edu",
-		 role = c("aut")),
+		 role = c("aut"), comment = c(ORCID = "0000-0003-4366-933X")),
 	person("Natalie", "Del Rossi", email = "natalie.delrossi@mssm.edu",
 		 role = c("aut"))
 	)
 Description: Toolbox to process, analyze and visualize spatial single-cell expression data.
 License: MIT + file LICENSE
 Encoding: UTF-8
-URL: https://giotto-suite.github.io/Giotto/, https://github.com/giotto-suite/Giotto
+URL: https://giottosuite.com, https://github.com/giotto-suite/Giotto
 BugReports: https://github.com/giotto-suite/Giotto/issues
 RoxygenNote: 7.3.3
 Depends:


### PR DESCRIPTION
Two one-line fixes to `DESCRIPTION`. The same change is already on `gsource`.

### `URL:` pointed at a site that is not the Giotto site

It advertised `https://giotto-suite.github.io/Giotto/`. That address is GitHub
Pages rendering this repository's README from the `suite` branch — its root
returns 200, but `/reference/index.html`, `/articles/index.html` and
`/pkgdown.yml` all 404.

Because it serves no `pkgdown.yml`, other packages in the suite cannot resolve
Giotto topics at all, so cross-package references to Giotto functions render as
plain text instead of links. GiottoData's homepage still shows one such
unresolvable link today.

The real site is https://giottosuite.com, built from `Giotto_website`.

### Wen Wang's ORCID had gone missing from the site

`Giotto_website` used to carry its own copy of this file, and that copy had the
ORCID while the package never did. When the release build switched to
documenting a checkout of this package, the copy went away and the ORCID link
disappeared from giottosuite.com.

### Notes

- Also being cleaned up separately: GitHub Pages on this repository will be
  disabled, since it only shadows the real site.
- The site does not rebuild automatically on changes here, so a
  `Giotto_website` release build needs dispatching for the ORCID to reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)