### PR TITLE
Read Xenium ome.tif images directly, without converting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * `runUMAP()` defaults retuned to match the benchmarked streaming pipeline: `min_dist` `0.01` -> `0.05`, `spread` `5` -> `1`, and a new `batch = TRUE` argument (was `FALSE`). `min_dist` and `spread` are changed together because uwot fits the embedding's `a`/`b` curve from the pair. `batch = TRUE` is also what lets `umap2()` thread the optimizer. **Embeddings will differ from previous releases**; `min_dist = 0.01, spread = 5, init = "spectral", n_epochs = 400, batch = FALSE` restores the old shape. `n_neighbors` is unchanged at `40`.
 
 ## Changes
+* `createGiottoXeniumObject()` reads `ome.tif` morphology images directly and no longer converts them through python, so no `tif_exports/` directory is written next to the data. A converted tif left by an earlier run is still used if present. JPEG-2000 images, which is what 10x actually ships, are read through a GDAL VRT rather than decoded up front.
 * gini `min_expr_gini_score` and `min_det_gini_score` renamed `min_expression` and `min_detection` — they gate mean expression and detection fraction, not the gini coefficients. Old names deprecated. [#1238](https://github.com/drieslab/Giotto/pull/1238) by eryuluts
 
 ## New

--- a/R/convenience_xenium.R
+++ b/R/convenience_xenium.R
@@ -1628,61 +1628,66 @@ importXenium <- function(xenium_dir = NULL, qv_threshold = 20, backend = NULL) {
         }
 
         bn <- basename(path)
-        # Primary expected path matches `GiottoClass::to_simple_tif`'s
-        # current convention (commit de206ed4, GiottoClass 0.5.x+) which
-        # appends `_page<NNNN>` to every output (default page = 1).
-        # Legacy un-suffixed path is kept as a fallback for older
-        # GiottoClass installs
+        # `.ome.tif` no longer needs converting -- GiottoClass reads it
+        # directly, routing JPEG-2000 tiles through a GDAL VRT. A tif left
+        # behind by an earlier run is still honoured so that repeat calls on
+        # a dataset converted by an older Giotto keep working.
+        # `to_simple_tif`'s current convention (GiottoClass 0.5.x+) appends
+        # `_page<NNNN>`; the un-suffixed path is from older installs.
         tiff_path_new <- file.path(output_dir,
             sub("(?i)\\.ome\\.tif{1,2}$", "_page0001.tif", bn, perl = TRUE))
         tiff_path_legacy <- file.path(output_dir,
             sub("(?i)\\.ome\\.tif{1,2}$", ".tif", bn, perl = TRUE))
-        .resolve_tiff <- function() {
-            if (checkmate::test_file_exists(tiff_path_new)) tiff_path_new
-            else if (checkmate::test_file_exists(tiff_path_legacy)) tiff_path_legacy
-            else NA_character_
+        tiff_path <- if (checkmate::test_file_exists(tiff_path_new)) {
+            tiff_path_new
+        } else if (checkmate::test_file_exists(tiff_path_legacy)) {
+            tiff_path_legacy
+        } else {
+            NA_character_
         }
-        tiff_path <- .resolve_tiff()
 
         if (!is.na(tiff_path)) {
-            vmsg(.is_debug = TRUE, sprintf(
-                "converted tiff already present\n%s", tiff_path
-            ))
             if (isTRUE(overwrite)) {
+                vmsg(.is_debug = TRUE, sprintf(
+                    "removing stale converted tiff\n%s", tiff_path
+                ))
                 unlink(tiff_path, force = TRUE)
-                tiff_path <- NA_character_
-            }
-            # the convenience fun can be run multiple times on the dataset
-            # So, we allow directly using already converted imgs
-        }
-
-        if (is.na(tiff_path)) {
-            vmsg(.is_debug = TRUE, sprintf(
-                "converting ome to tif\n%s", tiff_path_new
-            ))
-            to_simple_tif(
-                input_file = path,
-                output_dir = output_dir,
-                overwrite = overwrite
-            )
-            tiff_path <- .resolve_tiff()
-            if (is.na(tiff_path)) {
-                stop("to_simple_tif produced no output at expected paths:\n  ",
-                    tiff_path_new, "\n  ", tiff_path_legacy,
-                    call. = FALSE)
+            } else {
+                vmsg(.is_debug = TRUE, sprintf(
+                    "using previously converted tiff\n%s", tiff_path
+                ))
+                path <- tiff_path
             }
         }
-
-        path <- tiff_path
     }
 
-    img <- createGiottoLargeImage(path,
+    img <- try(createGiottoLargeImage(path,
         name = name,
         flip_vertical = flip_vertical,
         flip_horizontal = flip_horizontal,
         negative_y = negative_y,
         verbose = verbose
-    )
+    ), silent = TRUE)
+
+    if (inherits(img, "try-error")) {
+        # last resort for codecs GDAL cannot reach: convert through python
+        vmsg(.is_debug = TRUE, "direct read failed, converting via python")
+        if (identical(output_dir, "default")) {
+            output_dir <- file.path(dirname(path), "tif_exports")
+        }
+        conv <- to_simple_tif(
+            input_file = path,
+            output_dir = output_dir,
+            overwrite = overwrite
+        )
+        img <- createGiottoLargeImage(conv,
+            name = name,
+            flip_vertical = flip_vertical,
+            flip_horizontal = flip_horizontal,
+            negative_y = negative_y,
+            verbose = verbose
+        )
+    }
     img <- rescale(img, micron, x0 = 0, y0 = 0)
 
     # NEW
@@ -1735,9 +1740,8 @@ importXenium <- function(xenium_dir = NULL, qv_threshold = 20, backend = NULL) {
 #' @param qv_threshold Minimum Phred-scaled quality score cutoff to be included
 #' as a subcellular transcript detection (default = 20)
 #' @param load_images Named list of filepaths to `.tif` images, usually the
-#' ones in the `morphology_focus` directory. These `ome.tif` images are not
-#' compatible and must be converted to `tif` using
-#' `[GiottoClass::to_simple_tif()]`.
+#' ones in the `morphology_focus` directory. `ome.tif` images are read
+#' directly, including the JPEG-2000 compressed ones Xenium ships.
 #' @param load_aligned_images Named list of filepaths. The list names are used
 #' as the image names when loaded. Two filepaths are expected per entry. The
 #' first one should be to the `.tif` image. The second path is to the `.csv`

--- a/man/createGiottoXeniumObject.Rd
+++ b/man/createGiottoXeniumObject.Rd
@@ -60,9 +60,8 @@ matched against the feature IDs information. See details.}
 as a subcellular transcript detection (default = 20)}
 
 \item{load_images}{Named list of filepaths to \code{.tif} images, usually the
-ones in the \code{morphology_focus} directory. These \code{ome.tif} images are not
-compatible and must be converted to \code{tif} using
-\verb{[GiottoClass::to_simple_tif()]}.}
+ones in the \code{morphology_focus} directory. \code{ome.tif} images are read
+directly, including the JPEG-2000 compressed ones Xenium ships.}
 
 \item{load_aligned_images}{Named list of filepaths. The list names are used
 as the image names when loaded. Two filepaths are expected per entry. The


### PR DESCRIPTION
Depends on giotto-suite/GiottoClass#391, but does not block on it — see *Merge order* below.

## What changed

`.xenium_image_single()` converted every `.ome.tif` through `GiottoClass::to_simple_tif()` before loading it. That needed a python environment with `tifffile` and `imagecodecs`, and left a `tif_exports/` directory inside the user's Xenium output folder.

GiottoClass now reads these directly — routing the JPEG-2000 tiles that 10x actually ships through a GDAL VRT — so the conversion step is dropped:

- no python on the image path, and nothing written next to the user's data
- a tif left behind by an earlier run is still used when present, so repeat calls on a dataset converted by an older Giotto keep working
- `to_simple_tif()` is retained as a caught fallback for codecs GDAL cannot reach
- `@file_path` now holds the original `.ome.tif` rather than the converted copy, which is what lets `reconnect()` rebuild the VRT in a later session

## Merge order

Safe either way. The direct read is wrapped in `try()`, so against an older GiottoClass it fails and the python fallback runs exactly as before — the only difference is when users stop paying the python cost. No version floor needed.

## Verification

Exercised end to end on a real 51187x17098 JPEG-2000 Xenium image:

- `giottoLargeImage` created, extent correct after `rescale()`, pixels reachable
- `@file_path` is the original `.ome.tif`
- no `tif_exports/` directory created
- backing raster is the VRT

Pixel equivalence against the previous python output is covered in GiottoClass#391 — **0 differing pixels** across five ROIs, identical extents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)