### PR TITLE
test: adopt GiottoData 0.3.x paths, drop vestigial suppressWarnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,7 @@ Suggests:
     FNN,
     future,
     future.apply,
-    GiottoData,
+    GiottoData (>= 0.3.0),
     GiottoDisk,
     ggalluvial,
     ggdendro,

--- a/tests/testthat/test_97_dataImports.R
+++ b/tests/testthat/test_97_dataImports.R
@@ -9,17 +9,20 @@
 # ------------------------------------
 
 test_that("Expression matrix is read correctly", {
-    # getSpatialDataset
-    expect_no_error(suppressWarnings(GiottoData::getSpatialDataset(
-        dataset = "scRNA_mouse_brain",
-        directory = paste0(getwd(), "/testdata/")
-    )))
+    # getSpatialDataset returns the directory it wrote to, which is a
+    # per-dataset subdirectory of `directory`
+    expect_no_error(
+        data_dir <- GiottoData::getSpatialDataset(
+            dataset = "scRNA_mouse_brain",
+            directory = file.path(getwd(), "testdata")
+        )
+    )
 
-    expect_true(file.exists(paste0(getwd(), "/testdata/brain_sc_expression_matrix.txt.gz")))
+    expr_file <- file.path(data_dir, "brain_sc_expression_matrix.txt.gz")
+    expect_true(file.exists(expr_file))
 
     # readExprMatrix
-    expr_mat <- readExprMatrix(
-        paste0(getwd(), "/testdata/brain_sc_expression_matrix.txt.gz"))
+    expr_mat <- readExprMatrix(expr_file)
 
     expect_s4_class(expr_mat, "dgCMatrix")
     expect_equal(expr_mat@Dim, c(27998, 8039))
@@ -40,10 +43,6 @@ test_that("Expression matrix is read correctly", {
 
 # -----------------------------
 # remove files after testing
-if (file.exists("./testdata/brain_sc_expression_matrix.txt.gz")) {
-    unlink("./testdata/brain_sc_expression_matrix.txt.gz")
-}
-
-if (file.exists("./testdata/brain_sc_metadata.csv")) {
-    unlink("./testdata/brain_sc_metadata.csv")
+if (dir.exists("./testdata/scRNA_mouse_brain")) {
+    unlink("./testdata/scRNA_mouse_brain", recursive = TRUE, force = TRUE)
 }

--- a/tests/testthat/test_99_merFISH.R
+++ b/tests/testthat/test_99_merFISH.R
@@ -4,15 +4,14 @@ describe("Integrative testing with merfish dataset", {
     skip_on_bioc()
     skip_if_offline()
     
-    # data setup (warning about non-existing dir expected)
+    # data setup. getSpatialDataset returns the directory it wrote to, which
+    # is a per-dataset subdirectory of `directory`
     data_dir <- file.path(tempdir(), "testdata", "merfish")
-    suppressWarnings(
-        GiottoData::getSpatialDataset(
-            dataset = "merfish_preoptic", 
-            directory = data_dir
-        )
+    dataset_dir <- GiottoData::getSpatialDataset(
+        dataset = "merfish_preoptic",
+        directory = data_dir
     )
-    
+
     # register cleanup
     on.exit({
         # remove downloaded datasets after tests run
@@ -20,10 +19,10 @@ describe("Integrative testing with merfish dataset", {
             unlink(data_dir, recursive = TRUE, force = TRUE)
         }
     }, add = TRUE)
-    
-    expr_path <- file.path(data_dir, "merFISH_3D_data_expression.txt.gz")
-    loc_path  <- file.path(data_dir, "merFISH_3D_data_cell_locations.txt")
-    meta_path <- file.path(data_dir, "merFISH_3D_metadata.txt")
+
+    expr_path <- file.path(dataset_dir, "merFISH_3D_data_expression.txt.gz")
+    loc_path  <- file.path(dataset_dir, "merFISH_3D_data_cell_locations.txt")
+    meta_path <- file.path(dataset_dir, "merFISH_3D_metadata.txt")
     
     # CREATE GIOTTO OBJECT
     object <- createGiottoObject(


### PR DESCRIPTION
Both `getSpatialDataset()` call sites in the test suite wrap it in `suppressWarnings()`. That was hiding the `The output directory does not exist and will be created` warning, which GiottoData 0.3.0 replaced with a verbose message — so the suppression now hides nothing and would mask a real problem.

Removing it alone would not be correct, though: the same release also changed where files land, and that breaks these tests independently.

## What changed

`getSpatialDataset()` now writes into a **per-dataset subdirectory** of `directory` and returns that path. The flat paths these tests assert therefore no longer exist:

```r
# before — this file is no longer written here
expect_true(file.exists(paste0(getwd(), "/testdata/brain_sc_expression_matrix.txt.gz")))

# after — use the path the function hands back
data_dir <- GiottoData::getSpatialDataset(
    dataset = "scRNA_mouse_brain",
    directory = file.path(getwd(), "testdata")
)
expect_true(file.exists(file.path(data_dir, "brain_sc_expression_matrix.txt.gz")))
```

Same treatment in `test_99_merFISH.R` for the three `merFISH_3D_*` paths, and `test_97`'s teardown now removes the dataset directory rather than two individual filenames.

`DESCRIPTION` gains `GiottoData (>= 0.3.0)`. Without that floor this change would be wrong against an older GiottoData, where the warning is real and the paths are flat — it was previously unversioned.

## Verification

Run against GiottoData 0.3.5 installed to a temporary library:

| file | result |
|---|---|
| `test_97_dataImports.R` | **6 pass, 0 fail, 0 warn** |
| `test_99_merFISH.R` (`NOT_CRAN=true`) | 58 pass, 5 fail, **0 warn** |

The 5 failures in `test_99` are **pre-existing and unrelated**. Baseline check: the unmodified file against the previously installed GiottoData 0.2.15 gives **the identical 58 pass / 5 fail / 0 warn**, failing on the same five assertions — `leiden_0.2` cluster labels at indices 10 and 80, `nrow(markers)` (590 vs 585), and `cell_types` at indices 5 and 250. Those are clustering and marker-value drift, untouched here.

The `0 warn` in both columns is the point: with the suppression gone, nothing is being swallowed.

The remaining `suppressWarnings()` in `test_99_merFISH.R` around `runPCA()` is unrelated and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)