### PR TITLE
refactor: own the spatial-network-to-igraph shaping

### DIFF
--- a/R/spatial_clusters.R
+++ b/R/spatial_clusters.R
@@ -62,8 +62,7 @@ spatialSplitCluster <- function(
 
     clus_info <- cell_meta[, c("cell_ID", cluster_col), with = FALSE]
     # subset to needed cols
-    g <- GiottoClass::spat_net_to_igraph(sn)
-    # convert spatialNetworkObject to igraph
+    g <- .spat_net_to_igraph(sn)
 
     # assign cluster info to igraph nodes
     clus_values <- clus_info[
@@ -167,8 +166,7 @@ identifyTMAcores <- function(
         verbose = FALSE,
     )
 
-    g <- GiottoClass::spat_net_to_igraph(sn)
-    # convert spatialNetworkObject to igraph
+    g <- .spat_net_to_igraph(sn)
 
     # get new clusterings as initial indices
     # these indices may need repairs and updates to be finalized
@@ -288,6 +286,38 @@ identifyTMAcores <- function(
 
 
 # internals ####
+
+
+#' @title Spatial network as an undirected igraph
+#' @name .spat_net_to_igraph
+#' @description Read a `spatialNetworkObj` as the undirected, attribute-free
+#' igraph the clustering helpers below expect.
+#'
+#' `as.igraph()` returns the graph the `@network` slot holds, unchanged -- a
+#' kNN network is stored directed and carries `weight`/`distance`. Neither
+#' suits `.igraph_vertex_membership()` or `.igraph_remove_hetero_edges()`, so
+#' the shaping happens here, next to the code that needs it, rather than in
+#' GiottoClass where nothing consumed it.
+#' @param x spatialNetworkObj
+#' @param attr character. Edge attributes to keep. Default keeps none.
+#' @returns igraph
+#' @noRd
+#' @keywords internal
+.spat_net_to_igraph <- function(x, attr = NULL) {
+    net <- igraph::as.igraph(x)
+
+    # `mode = "each"` rather than "collapse": reciprocal kNN pairs stay two
+    # edges. No-op on an already-undirected network such as Delaunay.
+    if (igraph::is_directed(net)) {
+        net <- igraph::as_undirected(net, mode = "each")
+    }
+
+    drop <- setdiff(igraph::edge_attr_names(net), attr)
+    for (a in drop) net <- igraph::delete_edge_attr(net, a)
+
+    net
+}
+
 
 #' @title Remove hetero edges from igraph
 #' @name .igraph_remove_hetero_edges

--- a/tests/testthat/test-spatial-clusters.R
+++ b/tests/testthat/test-spatial-clusters.R
@@ -1,0 +1,106 @@
+# spatialSplitCluster() and identifyTMAcores() had no coverage. Both were
+# unusable on any in-memory spatial network for the whole 0.6.0 cycle --
+# `spatIDs()` and the old GiottoClass helper both read `@network` as the
+# from/to table it stopped holding -- and nothing caught it. These pin the
+# shape both functions need from `.spat_net_to_igraph()`.
+
+rlang::local_options(lifecycle_verbosity = "quiet")
+
+.net_gobject <- function(method = "Delaunay") {
+    g <- test_data$vis
+    GiottoClass::createSpatialNetwork(
+        g,
+        method = method,
+        name = paste0(method, "_network"),
+        verbose = FALSE
+    )
+}
+
+
+# .spat_net_to_igraph ####
+
+test_that(".spat_net_to_igraph returns an undirected graph with named nodes", {
+    g <- .net_gobject("Delaunay")
+    sn <- GiottoClass::getSpatialNetwork(
+        g, name = "Delaunay_network", output = "spatialNetworkObj"
+    )
+
+    net <- .spat_net_to_igraph(sn)
+    expect_s3_class(net, "igraph")
+    expect_false(igraph::is_directed(net))
+    # vertex names are the cell_IDs both callers match metadata on
+    expect_true(all(nzchar(names(igraph::V(net)))))
+    expect_gt(igraph::vcount(net), 0L)
+    expect_gt(igraph::ecount(net), 0L)
+})
+
+test_that(".spat_net_to_igraph drops edge attributes unless asked", {
+    g <- .net_gobject("Delaunay")
+    sn <- GiottoClass::getSpatialNetwork(
+        g, name = "Delaunay_network", output = "spatialNetworkObj"
+    )
+    stored <- igraph::as.igraph(sn)
+    # the stored graph carries them; the shaped one should not
+    expect_true(length(igraph::edge_attr_names(stored)) > 0L)
+
+    expect_length(igraph::edge_attr_names(.spat_net_to_igraph(sn)), 0L)
+    expect_identical(
+        igraph::edge_attr_names(.spat_net_to_igraph(sn, attr = "distance")),
+        "distance"
+    )
+})
+
+test_that(".spat_net_to_igraph undirects kNN without collapsing edges", {
+    g <- .net_gobject("kNN")
+    sn <- GiottoClass::getSpatialNetwork(
+        g, name = "kNN_network", output = "spatialNetworkObj"
+    )
+    stored <- igraph::as.igraph(sn)
+    skip_if_not(igraph::is_directed(stored), "kNN network not stored directed")
+
+    net <- .spat_net_to_igraph(sn)
+    expect_false(igraph::is_directed(net))
+    # mode = "each": reciprocal pairs stay two edges rather than collapsing
+    expect_equal(igraph::ecount(net), igraph::ecount(stored))
+    expect_equal(igraph::vcount(net), igraph::vcount(stored))
+})
+
+
+# the two callers ####
+
+test_that("spatialSplitCluster splits a cluster column by spatial adjacency", {
+    g <- .net_gobject("Delaunay")
+    cm <- GiottoClass::pDataDT(g)
+    skip_if_not("leiden_clus" %in% colnames(cm), "no leiden_clus in mini")
+
+    out <- spatialSplitCluster(
+        g,
+        spatial_network_name = "Delaunay_network",
+        cluster_col = "leiden_clus",
+        return_gobject = TRUE
+    )
+    res <- GiottoClass::pDataDT(out)
+
+    expect_true("leiden_clus_split" %in% colnames(res))
+    # the regression: an empty vertex set produced no assignments at all
+    expect_false(all(is.na(res$leiden_clus_split)))
+    expect_gte(
+        data.table::uniqueN(res$leiden_clus_split),
+        data.table::uniqueN(res$leiden_clus)
+    )
+})
+
+test_that("identifyTMAcores assigns core ids", {
+    g <- .net_gobject("Delaunay")
+
+    out <- identifyTMAcores(
+        g,
+        spatial_network_name = "Delaunay_network",
+        return_gobject = TRUE
+    )
+    res <- GiottoClass::pDataDT(out)
+
+    expect_true("core_id" %in% colnames(res))
+    expect_false(all(is.na(res$core_id)))
+    expect_gt(data.table::uniqueN(res$core_id), 0L)
+})


### PR DESCRIPTION
Moves `spat_net_to_igraph()` out of GiottoClass and into this package as an internal.

## Why here

GiottoClass exported it and it was only used in Giotto.

| package | references |
|---|---|
| GiottoClass | 1 — the definition itself, zero callers |
| Giotto | 2 — both in `R/spatial_clusters.R` |
| everything else | none |

Its contract is not general coercion. It undirects with `mode = "each"` and strips edge attributes, and both exist purely to satisfy the two clustering helpers in that same file:

- `.igraph_vertex_membership()` runs `igraph::components()`
- `.igraph_remove_hetero_edges()` selects with `%--%`

That is a consumer concern, so it now lives next to its consumers as `.spat_net_to_igraph()`, beside the two `.igraph_*` helpers it feeds.

## What replaces it in GiottoClass

`as.igraph()` on a `spatialNetworkObj` / `nnNetObj` returns the graph `@network` holds, unchanged. That keeps it a faithful accessor and keeps it agreeing with `getSpatialNetwork(output = "igraph")`, which already returns the slot verbatim. Reshaping it to one consumer's needs would have made two accessors disagree about the same object, and would have silently undirected a kNN network on `createSpatNetObj(network = as.igraph(sn))` round-trips.

Depends on giotto-suite/GiottoClass#398 (merged) for `as.igraph()`. A follow-up removes the old export from GiottoClass — **this must merge first**, or that removal breaks these two callers.

## Tests

`tests/testthat/test-spatial-clusters.R` — 17 assertions, 0 skips.

These are the **first tests either caller has had**. Nothing in `tests/` referenced `spatialSplitCluster` or `identifyTMAcores`, which is how both shipped unusable on every in-memory spatial network for the whole 0.6.0 cycle: `@network` became an igraph, `$from`/`$to` on an igraph is `NULL`, and the failure surfaced as `character(0)` nodes and *please supply names for attributes* rather than anything a reader would connect to the migration.

Coverage pins the three properties the callers actually depend on — undirected output, named vertices for the metadata `match()`, and edge attributes dropped unless requested — plus an end-to-end assertion on each caller.